### PR TITLE
fix: restore template sync integrity after #10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,17 @@ mobile: ios android js
 # Sync the canonical native shells into the CLI scaffolding templates.
 # ios/Irgo and android/app are the single source of truth; run this after
 # editing them so `irgo new` scaffolds current code.
-# (IrgoWebViewController.swift is excluded: the template variant adds
-# dev-mode support and is maintained by hand.)
-ANDROID_SHELL_FILES = IrgoActivity IrgoBridge IrgoJSInterface IrgoNative IrgoPlugins IrgoWebViewClient
-IOS_SHELL_FILES = IrgoBridge IrgoSchemeHandler IrgoWebSocketBridge IrgoNative IrgoPlugins
+# Intentionally excluded from sync:
+#  - IrgoWebViewController.swift: the template variant adds dev-mode support
+#    and is maintained by hand.
+#  - IrgoBridge.kt / IrgoBridge.swift: the framework repo binds irgo/mobile
+#    directly (responses are core.Response / CoreResponse), while scaffolded
+#    projects bind their own mobile wrapper with a local Response type
+#    (mobile.Response / MobileResponse) — gobind drops functions whose
+#    signatures reference types from a dependency module, so the scaffold
+#    cannot reuse core.Response. The two variants are maintained by hand.
+ANDROID_SHELL_FILES = IrgoActivity IrgoJSInterface IrgoNative IrgoPlugins IrgoWebViewClient
+IOS_SHELL_FILES = IrgoSchemeHandler IrgoWebSocketBridge IrgoNative IrgoPlugins
 
 sync-templates:
 	@for f in $(ANDROID_SHELL_FILES); do \

--- a/ios/Irgo/IrgoWebSocketBridge.swift
+++ b/ios/Irgo/IrgoWebSocketBridge.swift
@@ -29,13 +29,16 @@ public class IrgoWebSocketBridge: NSObject {
     /// - Returns: Session ID
     public func connect(url: String) throws -> String {
         var error: NSError?
+        // MobileWebSocketConnect returns a non-optional String (gomobile
+        // generates `NSString* _Nonnull` + explicit error pointer), so there
+        // is nothing to conditionally bind — just reject empty sessions.
         let sessionID = MobileWebSocketConnect(url, &error)
 
         if let error = error {
             throw error
         }
 
-        guard let sessionID = sessionID, !sessionID.isEmpty else {
+        guard !sessionID.isEmpty else {
             throw IrgoError.bridgeNotInitialized
         }
 
@@ -63,9 +66,11 @@ public class IrgoWebSocketBridge: NSObject {
 
     /// Close a virtual WebSocket connection
     public func close(sessionID: String) {
-        do {
-            try MobileWebSocketClose(sessionID)
-        } catch {
+        var error: NSError?
+        // MobileWebSocketClose takes an explicit error pointer (gomobile
+        // generates `BOOL ... (sessionID, NSError** error)`).
+        MobileWebSocketClose(sessionID, &error)
+        if let error = error {
             print("Irgo: error closing WebSocket: \(error)")
         }
         lock.lock()


### PR DESCRIPTION
## Summary

Restores `make check-templates` (broken by the #10 merge) so the framework↔scaffold shell copies stay drift-checked:

- **Ports the `IrgoWebSocketBridge.swift` gomobile codegen fix to the canonical `ios/Irgo` copy.** #10 fixed it in the scaffold template only (non-optional `String` return from `MobileWebSocketConnect`, explicit `NSError` pointer for `MobileWebSocketClose` — both validated on-device); the canonical shell still had the old `guard let` / `do-try-catch` shapes that don't match what gomobile generates.
- **Documents and excludes the now-intentional `IrgoBridge.kt`/`.swift` divergence from the sync check.** The framework repo binds `irgo/mobile` directly (`core.Response`/`CoreResponse`), while scaffolded projects bind their own wrapper with a local `Response` type (`mobile.Response`/`MobileResponse`) — required because gobind drops functions whose signatures reference dependency-module types (#10's finding). The Makefile now explains this instead of flagging it as drift.

`make check-templates` passes again; the other nine shell files remain byte-identical and drift-checked.

## Test plan

- `make check-templates` ✅ (was failing on 3 files after #10)
- `go build ./...` / `go test ./...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FQRGBPqBpiSy8iGZ4BMEg

---
_Generated by [Claude Code](https://claude.ai/code/session_016FQRGBPqBpiSy8iGZ4BMEg)_