### PR TITLE
fix(datastarjs): the served bundle points at a source map that is not shipped

### DIFF
--- a/pkg/datastarjs/datastarjs.go
+++ b/pkg/datastarjs/datastarjs.go
@@ -20,6 +20,7 @@
 package datastarjs
 
 import (
+	"bytes"
 	_ "embed"
 	"net/http"
 	"strconv"
@@ -34,7 +35,32 @@ import (
 const Version = "v1.0.2"
 
 //go:embed datastar.js
-var script []byte
+var embedded []byte
+
+// script is the bundle with its source-map reference removed.
+//
+// The bundle ends with a //# sourceMappingURL=datastar.js.map comment, and the
+// map is not distributed — Datastar does not publish it and it is not vendored
+// here. A browser only fetches a map when devtools are open, so the dangling
+// reference is invisible in normal use and every irgo project has been serving
+// it. It is not invisible to everything: a headless browser that resolves the
+// comment eagerly fails to compile the whole client, which is how this was
+// found.
+var script = stripSourceMap(embedded)
+
+func stripSourceMap(b []byte) []byte {
+	const marker = "//# sourceMappingURL="
+	i := bytes.LastIndex(b, []byte(marker))
+	if i < 0 {
+		return b
+	}
+	// Keep anything after the comment's line, in case it is not last.
+	rest := b[i:]
+	if nl := bytes.IndexByte(rest, '\n'); nl >= 0 {
+		return append(bytes.Clone(b[:i]), rest[nl+1:]...)
+	}
+	return bytes.TrimRight(b[:i], "\n\r\t ")
+}
 
 // Script returns the Datastar client source, for builds that embed it rather
 // than serve it — the mobile shells read it through the same bridge as

--- a/pkg/datastarjs/datastarjs_test.go
+++ b/pkg/datastarjs/datastarjs_test.go
@@ -62,3 +62,17 @@ func TestGoAndClientAgreeOnTheWireFormat(t *testing.T) {
 		}
 	}
 }
+
+// TestServedClientHasNoDanglingSourceMap — the bundle ships with a
+// //# sourceMappingURL comment and the map is not distributed with it. A
+// browser only resolves that when devtools are open, so every generated
+// project served a dead reference without anyone noticing. Anything that
+// resolves it eagerly fails to compile the client at all.
+func TestServedClientHasNoDanglingSourceMap(t *testing.T) {
+	if strings.Contains(string(Script()), "sourceMappingURL") {
+		t.Error("the served client still references a source map that is not shipped")
+	}
+	if !strings.Contains(string(Script()), "datastar") {
+		t.Error("stripping the source map appears to have eaten the bundle")
+	}
+}


### PR DESCRIPTION
The Datastar bundle ends with `//# sourceMappingURL=datastar.js.map`, and the map is neither published upstream nor vendored here. A browser only fetches a map when devtools are open, so the dangling reference is invisible in normal use — every irgo project has been serving it.

It is not invisible to everything. A headless browser that resolves the comment eagerly fails to compile the client at all, which is how this surfaced: a DOM test harness could not load Datastar, and the cause looked like a missing `EventSource` until the real reason showed up in the fetch log.

The reference is stripped once at init rather than per request, and a test asserts both that it is gone and that stripping it did not eat the bundle.

---

**Independent** — based directly on `main`, no dependencies. 2 files.

Part of splitting up what should never have been one branch. See #10, which was opened from `main` and carried far too much; this is the first of five focused pieces.