### PR TITLE
feat(tools): one table says where every tool is and how to get it

### DIFF
--- a/cmd/irgo/cmd_tools.go
+++ b/cmd/irgo/cmd_tools.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +12,23 @@ import (
 	"runtime"
 	"strings"
 )
+
+// Where irgo keeps what it installs.
+//
+// These paths were spelled out with filepath.Join(homeDir(), ".irgo", ...) in
+// seven places across four files, so nothing owned the layout and moving it
+// meant finding them all. Every caller asks here now.
+func irgoHome() string { return filepath.Join(homeDir(), ".irgo") }
+
+// irgoBinDir holds single-binary tools irgo downloads.
+func irgoBinDir() string { return filepath.Join(irgoHome(), "bin") }
+
+// goTools are the tools irgo installs with `go install`.
+//
+// This list was written out in five places — install, remove, doctor and two
+// tests — and had already drifted: install was missing gobind, so `tools
+// install` left behind a tool that `tools remove` then offered to delete.
+func goTools() []string { return []string{"templ", "air", "gomobile", "gobind"} }
 
 // runTempl generates templ files
 func runTempl() error {
@@ -34,6 +52,11 @@ const pinTempl = "v0.3.977"
 // build nobody can reproduce.
 const pinAir = "v1.63.0"
 
+// sops decrypts the secrets a deploy needs, when a project keeps them
+// encrypted in the repository rather than in a keychain. Installed when a
+// fnox.toml actually declares a sops provider, not before.
+const pinSops = "v3.12.2"
+
 func goToolPkg(name string) string {
 	switch name {
 	case "templ":
@@ -47,6 +70,8 @@ func goToolPkg(name string) string {
 		return "github.com/a-h/templ/cmd/templ@" + pinTempl
 	case "air":
 		return "github.com/air-verse/air@" + pinAir
+	case "sops":
+		return "github.com/getsops/sops/v3/cmd/sops@" + pinSops
 	case "gomobile", "gobind":
 		// Same commit as the x/mobile checkout gomobile builds against.
 		// Installing @latest while pinning the source is how a tool ends up
@@ -65,7 +90,7 @@ func goToolPkg(name string) string {
 // played safe and skipped them, leave a half-provisioned machine that silently
 // fails to re-provision.
 func irgoToolsDir() string {
-	return filepath.Join(homeDir(), ".irgo", "tools")
+	return filepath.Join(irgoHome(), "tools")
 }
 
 func markToolInstalled(name string) {
@@ -106,6 +131,17 @@ func ensureGoTool(name string) error {
 	if _, err := exec.LookPath(name); err == nil {
 		return nil
 	}
+	// mise first when it can provide the tool: it installs into a directory
+	// the developer's own version manager can see and clean up, rather than a
+	// GOBIN that irgo then has to prepend to PATH. Only some are in its
+	// registry — templ, gomobile and gobind are not — so `go install` remains
+	// the answer for the rest, and the fallback for all of them.
+	if spec, ok := miseSpec(name); ok {
+		if bin := miseTool(spec, name); bin != "" {
+			markToolInstalled(name)
+			return prependToPATH(filepath.Dir(bin))
+		}
+	}
 	pkg := goToolPkg(name)
 	if pkg == "" {
 		return fmt.Errorf("%s not found, and no install source is known for it", name)
@@ -126,6 +162,68 @@ func ensureGoTool(name string) error {
 	return nil
 }
 
+// miseSpec maps a tool to what mise is asked for, at irgo's own pin.
+//
+// Every one of these was verified to resolve — `mise ls-remote <spec>` lists
+// the exact version. An earlier version of this table claimed templ, gomobile
+// and tailwindcss were not available, on the strength of grepping
+// `mise registry`, which is capped at a thousand entries and lists none of
+// them. The backends have them all.
+//
+// The pin travels in the spec, so no mise.toml is involved and the developer's
+// own config is never consulted: `mise install templ@0.3.977` means that
+// version whatever their config says.
+func miseSpec(name string) (spec string, ok bool) {
+	v := func(pin string) string { return strings.TrimPrefix(pin, "v") }
+	switch name {
+	case "templ":
+		if p := templVersionFromGoMod(); p != "" {
+			return "go:github.com/a-h/templ/cmd/templ@" + p, true
+		}
+		return "go:github.com/a-h/templ/cmd/templ@" + v(pinTempl), true
+	// The short registry name, not the backend-qualified one. mise installs
+	// sops@3.12.2 and aqua:getsops/sops@3.12.2 into different directories, so
+	// asking for the qualified form would ignore a sops the developer already
+	// had and install a second copy beside it. tailwindcss is the exception:
+	// it is not in the registry, so only the backend spec resolves.
+	case "air":
+		return "air@" + v(pinAir), true
+	case "sops":
+		return "sops@" + v(pinSops), true
+	case "gomobile":
+		return "go:golang.org/x/mobile/cmd/gomobile@" + pinXMobile, true
+	case "gobind":
+		return "go:golang.org/x/mobile/cmd/gobind@" + pinXMobile, true
+	}
+	return "", false
+}
+
+// miseSpecFor covers every tool with a mise spec, including the two that are
+// not go-installed.
+func miseSpecFor(name string) (string, bool) {
+	switch name {
+	case "tailwindcss":
+		return "aqua:tailwindlabs/tailwindcss@" + strings.TrimPrefix(pinTailwind, "v"), true
+	case "node":
+		return "node@" + pinNode, true
+	case "jdk":
+		// doctor calls the row jdk; mise calls it java. Missing this pruned
+		// the marker for a JDK that was installed and in use, which would have
+		// left tools remove unable to give it back.
+		return "java@" + pinJDK, true
+	}
+	return miseSpec(name)
+}
+
+// prependToPATH makes a freshly installed tool resolvable for the rest of
+// this process, wherever it landed.
+func prependToPATH(dir string) error {
+	if dir == "" {
+		return nil
+	}
+	return os.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 // runCSS rebuilds the Tailwind stylesheet. static/css/output.css is generated
 // and gitignored, but it is embedded into every build — so skipping it ships an
 // unstyled app. No-op for projects without a Tailwind entry point.
@@ -143,8 +241,9 @@ func runCSS() error {
 }
 
 // ensureAssets regenerates everything that is gitignored yet embedded into a
-// build: _templ.go and the Tailwind stylesheet. Every build path runs this, so
-// a fresh clone builds correctly without the caller sequencing it by hand.
+// build: _templ.go, the Tailwind stylesheet, and whatever the project
+// generates for itself. Every build path runs this, so a fresh clone builds
+// correctly without the caller sequencing it by hand.
 func ensureAssets() error {
 	if err := runTempl(); err != nil {
 		return err
@@ -152,24 +251,102 @@ func ensureAssets() error {
 	return runCSS()
 }
 
+// ensureAssetsAndGenerate is ensureAssets plus the project's own generators.
+//
+// Kept separate because ensureAssets is the hot path: .air.toml runs
+// `irgo project assets` on every save, and generators are not save-cheap. A
+// project whose generators shell out to `go test` turns one keystroke into a
+// test compile, and a watch loop into a fork bomb — 95 of them, the first time
+// this ran. Generation belongs where correctness matters and latency does not:
+// builds, deploys and tests.
+func ensureAssetsAndGenerate() error {
+	if err := ensureAssets(); err != nil {
+		return err
+	}
+	return runGoGenerate()
+}
+
+// runGoGenerate runs the project's own generators.
+//
+// Some projects derive content from source rather than typing it — a docs site
+// generating its API reference from go/doc, say. That belongs to the project,
+// not to irgo, so this runs the standard Go mechanism and stays ignorant of
+// what any particular project generates. A project with no //go:generate
+// directives spends a few milliseconds here and produces nothing.
+//
+// It runs after templ and Tailwind, so a generator can rely on a package that
+// compiles.
+func runGoGenerate() error {
+	if !hasGoGenerate() {
+		return nil
+	}
+	fmt.Println("Running go generate...")
+	return runCommand("go", "generate", "./...")
+}
+
+// hasGoGenerate reports whether the project declares any generator, so the
+// common case prints nothing and pays nothing.
+func hasGoGenerate() bool {
+	found := false
+	_ = filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil || found {
+			return nil
+		}
+		if info.IsDir() {
+			switch info.Name() {
+			case "node_modules", "vendor", "build", "tmp", ".git":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err == nil && bytes.Contains(data, []byte("\n//go:generate")) {
+			found = true
+		}
+		return nil
+	})
+	return found
+}
+
 // installTools installs required development tools
 func installTools() error {
 	fmt.Println("Installing irgo development tools...")
 	fmt.Println()
 
-	// ensureGoTool owns pinning (templ tracks the project's go.mod version),
-	// marker-writing for uninstall, and PATH fix-up. This is just the eager
-	// form of what every build does lazily.
-	for _, tool := range []string{"templ", "air", "gomobile"} {
-		if _, err := exec.LookPath(tool); err == nil {
-			fmt.Printf("  %s: already installed\n", tool)
+	// The same table doctor reports from, so `tools install` cannot provide a
+	// different set of tools than `tools doctor` describes. Each row carries
+	// how to get itself; this is the eager form of what every build does
+	// lazily when a call needs something.
+	//
+	// Skipped here: the heavy toolchains. The Android SDK is hundreds of
+	// megabytes and only an Android build needs it, so it stays lazy — the
+	// closing message says so.
+	eager := map[string]bool{}
+	for _, name := range goTools() {
+		eager[name] = true
+	}
+	eager["tailwindcss"] = true
+
+	for _, row := range toolLocators() {
+		if !eager[row.name] {
 			continue
 		}
-		if err := ensureGoTool(tool); err != nil {
+		if row.path != "" {
+			fmt.Printf("  %s: already installed\n", row.name)
+			continue
+		}
+		if row.ensure == nil {
+			fmt.Printf("  %s: not something irgo can install\n", row.name)
+			continue
+		}
+		if err := row.ensure(); err != nil {
 			fmt.Printf("  Warning: %v\n", err)
 			continue
 		}
-		fmt.Printf("  %s: installed\n", tool)
+		fmt.Printf("  %s: installed\n", row.name)
 	}
 
 	if err := installOSPackages(); err != nil {
@@ -249,9 +426,7 @@ func uninstallTools(scope string, all, yes, keepJDK bool) error {
 	case "android":
 		planAndroid(&p, keepJDK)
 	default:
-		planGoTools(&p, all)
-		planDownloads(&p)
-		planNode(&p)
+		planTools(&p, all)
 		planHostPackages(&p, all)
 		planAndroid(&p, keepJDK)
 	}
@@ -305,5 +480,5 @@ func pruneIrgoStateDir() {
 	// os.Remove only succeeds on an empty directory, which is exactly the
 	// condition we want — never delete state that is still in use.
 	_ = os.Remove(irgoToolsDir())
-	_ = os.Remove(filepath.Join(homeDir(), ".irgo"))
+	_ = os.Remove(irgoHome())
 }

--- a/cmd/irgo/cmd_tools_doctor.go
+++ b/cmd/irgo/cmd_tools_doctor.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -443,14 +442,14 @@ func printAndroidDetail() {
 		fmt.Println("  JDK 17        not found — fetched into ~/.irgo/jdks on first build")
 	}
 
-	ndk := filepath.Join(sdk, "ndk", pinNDK)
+	ndk := ndkDir(sdk)
 	if fi, err := os.Stat(ndk); err == nil && fi.IsDir() {
 		fmt.Printf("  NDK           %s\n", pinNDK)
 	} else {
 		fmt.Printf("  NDK           %s not installed — fetched on first build\n", pinNDK)
 	}
 
-	emu := filepath.Join(sdk, "emulator", "emulator")
+	emu := emulatorBin(sdk)
 	if runtime.GOOS == "windows" {
 		emu += ".exe"
 	}

--- a/cmd/irgo/cmd_tools_remove.go
+++ b/cmd/irgo/cmd_tools_remove.go
@@ -24,7 +24,10 @@ type removalPlan struct {
 	groups []planGroup
 	// kept lists things irgo did not install, which are reported and skipped.
 	kept []string
-	acts []func(*removalTally)
+	// notes are printed after the plan: things irgo will not touch, and what
+	// to run instead.
+	notes []string
+	acts  []func(*removalTally)
 }
 
 type planGroup struct {
@@ -58,6 +61,10 @@ func confirmRemoval(p *removalPlan, yes bool) (bool, error) {
 			fmt.Printf("  %s\n", l)
 		}
 	}
+	for _, n := range p.notes {
+		fmt.Println()
+		fmt.Println(n)
+	}
 	if len(p.kept) > 0 {
 		fmt.Println()
 		fmt.Printf("Kept (irgo did not install these): %s\n", strings.Join(p.kept, ", "))
@@ -73,100 +80,184 @@ func confirmRemoval(p *removalPlan, yes bool) (bool, error) {
 			"  Nothing has been deleted. Re-run with --yes to proceed:\n" +
 			"    irgo tools remove --yes")
 	}
-	fmt.Print("Proceed? [y/N] ")
+	if !confirm("Proceed?", false) {
+		fmt.Println("Nothing removed.")
+		return false, nil
+	}
+	return true, nil
+}
+
+// confirm asks, unless told not to. Outside a terminal it refuses rather than
+// assuming yes: a script that meant to pass --yes should say so.
+func confirm(question string, yes bool) bool {
+	if yes {
+		return true
+	}
+	if !interactive() {
+		return false
+	}
+	fmt.Printf("%s [y/N] ", question)
 	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
 	if err != nil {
-		return false, nil
+		return false
 	}
 	switch strings.ToLower(strings.TrimSpace(line)) {
 	case "y", "yes":
-		return true, nil
-	}
-	fmt.Println("Nothing removed.")
-	return false, nil
-}
-
-// planGoTools adds the go-installed tools irgo owns.
-func planGoTools(p *removalPlan, all bool) {
-	for _, tool := range []string{"templ", "air", "gomobile", "gobind"} {
-		t := tool
-		if !all && !toolInstalledByIrgo(t) {
-			if pathOnPATH(t) {
-				p.kept = append(p.kept, t)
-			}
-			continue
-		}
-		path := ""
-		for _, dir := range toolBinDirs() {
-			candidate := filepath.Join(dir, exeName(t))
-			if pathExists(candidate) {
-				path = candidate
-				break
-			}
-		}
-		if path == "" {
-			continue
-		}
-		p.add("Go tools", fmt.Sprintf("%-14s %s", t, path), func(tally *removalTally) {
-			if q := removeToolPath(t); q != "" {
-				tally.report(t, "removed", q)
-			} else {
-				tally.report(t, "absent", "")
-			}
-			clearToolMarker(t)
-		})
-	}
-}
-
-func pathOnPATH(name string) bool {
-	for _, dir := range toolBinDirs() {
-		if pathExists(filepath.Join(dir, exeName(name))) {
-			return true
-		}
+		return true
 	}
 	return false
 }
 
-// planDownloads adds the pinned binaries under ~/.irgo.
-func planDownloads(p *removalPlan) {
-	bin := filepath.Join(homeDir(), ".irgo", "bin")
-	entries, err := os.ReadDir(bin)
+// planGoTools adds the go-installed tools irgo owns.
+// planMiseTools offers back the tools irgo asked mise to install.
+//
+// Only those irgo installed: the marker decides. A mise tool that was already
+// on the machine belongs to the developer and probably to other projects too,
+// and uninstalling their node because irgo happened to use it would be the
+// worst thing this command could do.
+//
+// mise uninstall rather than deleting the directory, so mise's own view stays
+// correct.
+// planTools adds every tool irgo installed, from the table doctor reports.
+//
+// This replaced four planners — Go tools, mise tools, downloads, node — that
+// each rediscovered paths doctor had already found, in their own way. One of
+// them searched a different order than the build did, which is how remove
+// could offer a copy nothing was using.
+//
+// The table knows where each tool is and how to take it back; this decides
+// what to show and groups it.
+func planTools(p *removalPlan, all bool) {
+	var mise []toolStatus
+	claimed := map[string]bool{}
+	for _, row := range toolLocators() {
+		// Tools that live in mise are reported, not removed. See planMiseNote.
+		if row.how == "mise" {
+			mise = append(mise, row)
+			continue
+		}
+		// The Android section reports these with the rest of that toolchain,
+		// where they make sense together. Listing them here too offered the
+		// same JDK twice.
+		switch row.name {
+		case "jdk", "sdkmanager", "avdmanager", "adb", "emulator", "ndk":
+			if row.path != "" {
+				claimed[irgoOwnedDir(row.path)] = true
+			}
+			continue
+		}
+		if row.remove != nil && strings.HasPrefix(row.path, irgoHome()) {
+			claimed[irgoOwnedDir(row.path)] = true
+		}
+		if row.remove == nil {
+			// Nothing of irgo's to remove. Worth naming when it is present and
+			// irgo could have installed it, so the report is not silently
+			// short.
+			if row.path != "" && row.ensure != nil && !all {
+				p.kept = append(p.kept, row.name)
+			}
+			continue
+		}
+		name, undo := row.name, row.remove
+		where := row.path
+		if row.size != "" {
+			where += "  (" + row.size + ")"
+		}
+		p.add(removalGroup(row), fmt.Sprintf("%-14s %s", name, where),
+			func(tally *removalTally) {
+				if err := undo(); err != nil {
+					tally.report(name, "failed", err.Error())
+					return
+				}
+				tally.report(name, "removed", row.path)
+			})
+	}
+	planIrgoLeftovers(p, claimed)
+	planMiseNote(p, mise)
+}
+
+// planMiseNote lists the tools irgo uses from mise, with the command to
+// remove them — rather than removing them itself.
+//
+// irgo cannot tell which of these it installed. This machine's sops 3.12.2 was
+// installed in April and its tailwindcss today, both by the same mechanism
+// into the same place, and mise records no owner. A marker file could have
+// tracked it, at the cost of a folder to keep swept.
+//
+// But ownership is the wrong question. These live where the developer's own
+// version manager can see them and other projects may be using them, so the
+// decision is theirs — and printing the command costs nothing while getting it
+// wrong costs someone else's build.
+func planMiseNote(p *removalPlan, rows []toolStatus) {
+	if len(rows) == 0 {
+		return
+	}
+	var lines []string
+	for _, r := range rows {
+		if spec, ok := miseSpecFor(r.name); ok {
+			lines = append(lines, "  mise uninstall "+spec)
+		}
+	}
+	if len(lines) == 0 {
+		return
+	}
+	p.notes = append(p.notes,
+		"From mise (shared with anything else on this machine that uses them):",
+		strings.Join(lines, "\n"),
+		"  mise prune   # anything no config asks for")
+}
+
+// planIrgoLeftovers adds anything still sitting in ~/.irgo that no tool row
+// points at any more.
+//
+// The table only names the copy a build would use. Once node came from mise,
+// the 176 MB irgo had downloaded stopped being referenced by any row and
+// would have been left on disk forever — invisible to the one command whose
+// job is finding it.
+//
+// irgo owns ~/.irgo entirely, so anything in it is irgo's to offer back.
+func planIrgoLeftovers(p *removalPlan, claimed map[string]bool) {
+	entries, err := os.ReadDir(irgoHome())
 	if err != nil {
 		return
 	}
 	for _, e := range entries {
-		if !strings.HasPrefix(e.Name(), "tailwindcss") {
+		// tools holds the markers, bin is handled per-file, jdks belongs to
+		// the Android section which reports it with the rest of that toolchain.
+		switch e.Name() {
+		case "tools", "jdks":
 			continue
 		}
-		p.add("Downloads", fmt.Sprintf("%-14s %s", "tailwindcss", filepath.Join(bin, e.Name())),
+		dir := filepath.Join(irgoHome(), e.Name())
+		if claimed[dir] || !isDir(dir) {
+			continue
+		}
+		if empty, _ := os.ReadDir(dir); len(empty) == 0 {
+			continue
+		}
+		name := e.Name()
+		p.add("Downloads", fmt.Sprintf("%-14s %s%s", name, dir, dirSizeNote(dir)),
 			func(tally *removalTally) {
-				if q := removeTailwindPath(); q != "" {
-					tally.report("tailwindcss", "removed", q)
-				} else {
-					tally.report("tailwindcss", "absent", "")
+				if err := os.RemoveAll(dir); err != nil {
+					tally.report(name, "failed", err.Error())
+					return
 				}
+				clearToolMarker(name)
+				tally.report(name, "removed", dir)
 			})
-		return
 	}
 }
 
-// planNode adds the Node irgo downloads for wrangler. It is large and it is
-// only there for Cloudflare deploys, so leaving it behind after a removal
-// would be the kind of quiet leftover this command exists to prevent.
-func planNode(p *removalPlan) {
-	dir := managedNodeHome()
-	if !isDir(dir) {
-		return
+// removalGroup is the heading a tool appears under, taken from where it came
+// from rather than from a second list.
+func removalGroup(row toolStatus) string {
+	switch row.how {
+	case "mise":
+		return "mise tools"
+	case howGoInstall:
+		return "Go tools"
 	}
-	p.add("Downloads", fmt.Sprintf("%-14s %s%s", "node", dir, dirSizeNote(dir)),
-		func(tally *removalTally) {
-			if err := os.RemoveAll(dir); err != nil {
-				tally.report("node", "failed", err.Error())
-				return
-			}
-			clearToolMarker("node")
-			tally.report("node", "removed", dir)
-		})
+	return "Downloads"
 }
 
 // planHostPackages adds packages installed through the host package manager.
@@ -218,8 +309,9 @@ func planAndroid(p *removalPlan, keepJDK bool) {
 		p.kept = append(p.kept, "android SDK (not provisioned by irgo)")
 	}
 
-	jdk := filepath.Join(home, ".irgo", "jdks")
-	if !keepJDK && pathExists(jdk) {
+	// The JDK, when irgo downloaded it. A JDK from mise belongs to mise, and
+	// `mise uninstall java@...` is how it goes.
+	if jdk := managedJDKRoot(); !keepJDK && pathExists(jdk) {
 		p.add("Android", fmt.Sprintf("%-14s %s%s", "JDK 17", jdk, dirSizeNote(jdk)), func(tally *removalTally) {
 			if os.RemoveAll(jdk) == nil {
 				tally.report("managed-jdk", "removed", jdk)

--- a/cmd/irgo/tools_android_sdk.go
+++ b/cmd/irgo/tools_android_sdk.go
@@ -90,7 +90,35 @@ func isJava17(bin string) bool {
 // is fully self-contained and cross-platform — no brew/apt/winget anywhere.
 const managedJDKRel = ".irgo/jdks/temurin-17"
 
+// pinJDK is the exact Temurin build the Android toolchain uses.
+//
+// irgo's own downloader asks Adoptium for latest/17/ga, so two developers who
+// ran it months apart get different JDKs and neither can say which. mise can
+// name the build, so when it is doing the installing the version is pinned
+// like every other tool. The Adoptium fallback keeps its old behaviour, since
+// there is nothing to pin it to.
+const pinJDK = "temurin-17.0.20+8"
+
 func managedJDKHome() string { return filepath.Join(homeDir(), managedJDKRel) }
+
+// managedJDKRoot is the directory holding every JDK irgo has downloaded — the
+// parent of managedJDKHome. `tools remove` used to spell this out as
+// filepath.Join(home, ".irgo", "jdks"), which meant a change to managedJDKRel
+// would leave it deleting the wrong directory.
+func managedJDKRoot() string { return filepath.Dir(managedJDKHome()) }
+
+// ndkDir is the pinned NDK inside an SDK. Built in four places before this,
+// once of them in doctor, so doctor could look somewhere the build does not.
+func ndkDir(sdk string) string { return filepath.Join(sdk, "ndk", pinNDK) }
+
+// emulatorBin is the emulator inside an SDK. Also built in four places.
+func emulatorBin(sdk string) string {
+	name := "emulator"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(sdk, "emulator", name)
+}
 
 // findManagedJDK returns the extracted JDK home under ~/.irgo/jdks/temurin-17
 // (the Adoptium archive contains a single jdk-17.x.y/ dir — on macOS with a
@@ -117,6 +145,37 @@ func findManagedJDK() string {
 
 // installManagedJDK downloads a Temurin JDK 17 (Adoptium) for the current
 // platform/arch and extracts it into ~/.irgo/jdks/temurin-17. Returns its home.
+// miseJDK returns a JDK from mise, at irgo's pin.
+//
+// Returns "" when mise cannot supply it, which sends the caller to the
+// Adoptium download that has always been there.
+func miseJDK(install bool) string {
+	find := miseWhere
+	if install {
+		if bin := miseTool("java@"+pinJDK, "java"); bin != "" {
+			return javaHomeFor(bin)
+		}
+		return ""
+	}
+	mise, ok := miseCmd()
+	if !ok {
+		return ""
+	}
+	if bin := find(mise, "java@"+pinJDK, "java"); bin != "" {
+		return javaHomeFor(bin)
+	}
+	return ""
+}
+
+// javaHomeFor turns .../bin/java into the JAVA_HOME the Android tools want.
+func javaHomeFor(bin string) string {
+	home := filepath.Dir(filepath.Dir(bin))
+	if !isJava17(bin) {
+		return ""
+	}
+	return home
+}
+
 func installManagedJDK() (string, error) {
 	// Idempotent: reuse an already-extracted JDK 17.
 	if p := findManagedJDK(); p != "" && isJava17(filepath.Join(p, "bin", "java")) {
@@ -181,6 +240,12 @@ func installManagedJDK() (string, error) {
 // copy, macOS java_home, Linux /usr/lib/jvm, java on PATH. With install=true,
 // a missing JDK is downloaded cross-platform into ~/.irgo/jdks.
 func detectJDK17(install bool) (string, bool) {
+	// mise, at the pinned build, before irgo's own 308 MB download. Looked up
+	// whether or not this call may install, so doctor names the JDK a build
+	// would use rather than a second copy.
+	if home := miseJDK(false); home != "" {
+		return home, true
+	}
 	if jh := os.Getenv("JAVA_HOME"); jh != "" {
 		if isJava17(filepath.Join(jh, "bin", "java")) {
 			return jh, true
@@ -211,6 +276,11 @@ func detectJDK17(install bool) (string, bool) {
 		return "", true
 	}
 	if install {
+		// mise at the pinned build first: 308 MB that a machine with mise does
+		// not need a second copy of, and a version irgo can actually name.
+		if home := miseJDK(true); home != "" {
+			return home, true
+		}
 		p, err := installManagedJDK()
 		if err != nil {
 			fmt.Printf("  ! automatic JDK install failed: %v\n", err)
@@ -564,7 +634,7 @@ func ensureEmulatorRunning() error {
 	if adbRunning() {
 		return nil
 	}
-	emu := filepath.Join(androidHome(), "emulator", "emulator")
+	emu := emulatorBin(androidHome())
 	if runtime.GOOS == "windows" {
 		emu += ".exe"
 	}
@@ -759,7 +829,7 @@ func ensureAndroidToolchain(withEmulator bool, avdName string) error {
 
 	// Fast path: when the pinned NDK + platform-tools already exist the
 	// components are installed — skip the sdkmanager round-trip entirely.
-	ndk := filepath.Join(sdk, "ndk", pinNDK)
+	ndk := ndkDir(sdk)
 	if !isDir(ndk) || !isDir(filepath.Join(sdk, "platform-tools")) {
 		fmt.Println("Accepting Android SDK licenses...")
 		acceptLicenses(sdkm, sdk)
@@ -803,7 +873,7 @@ func installAndroidTools(withEmulator bool, avdName string) error {
 		return err
 	}
 	sdk := androidHome()
-	ndk := filepath.Join(sdk, "ndk", pinNDK)
+	ndk := ndkDir(sdk)
 	fmt.Printf("\nAndroid toolchain ready.\n")
 	fmt.Printf("  ANDROID_HOME=%s\n", sdk)
 	fmt.Printf("  ANDROID_NDK_HOME=%s\n", ndk)
@@ -892,7 +962,7 @@ func findAvdDir(avdName string) string {
 		}
 	}
 	// Ask the emulator where it thinks the AVD lives.
-	emu := filepath.Join(androidHome(), "emulator", "emulator")
+	emu := emulatorBin(androidHome())
 	if runtime.GOOS == "windows" {
 		emu += ".exe"
 	}
@@ -954,7 +1024,7 @@ func uninstallAndroidTools(removeJDK bool) error {
 	}
 	if removeJDK {
 		fmt.Println("Removing managed JDK (~/.irgo/jdks)...")
-		_ = os.RemoveAll(filepath.Join(home, ".irgo", "jdks"))
+		_ = os.RemoveAll(managedJDKRoot())
 		_ = os.Remove(filepath.Join(home, ".irgo")) // empty parent
 	}
 
@@ -983,8 +1053,8 @@ func uninstallAndroidTools(removeJDK bool) error {
 func doctorAndroid() error {
 	fail := false
 	sdk := androidHome()
-	ndk := filepath.Join(sdk, "ndk", pinNDK)
-	emulator := filepath.Join(sdk, "emulator", "emulator")
+	ndk := ndkDir(sdk)
+	emulator := emulatorBin(sdk)
 
 	fmt.Println("Android toolchain doctor:")
 	fmt.Printf("  ANDROID_HOME: %s\n", sdk)

--- a/cmd/irgo/tools_doctor_locators_test.go
+++ b/cmd/irgo/tools_doctor_locators_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -58,8 +59,15 @@ func toolsIrgoRuns() []string {
 		"templ": true, "air": true, "gomobile": true, "gobind": true,
 		"node": true, "java": true, "keytool": true, "adb": true,
 		"sdkmanager": true, "avdmanager": true, "go": true, "git": true,
-		"sops": true, "xcrun": true, "xcodebuild": true, "codesign": true,
-		"security": true, "clang": true,
+		"sops": true,
+	}
+	// Apple's tools are only expected where they can exist. doctor lists them
+	// on darwin and not elsewhere, correctly — so requiring them everywhere
+	// failed this on Linux while describing a real absence as a defect.
+	if runtime.GOOS == "darwin" {
+		for _, n := range []string{"xcrun", "xcodebuild", "codesign", "security", "clang"} {
+			want[n] = true
+		}
 	}
 	var names []string
 	for _, n := range strings.Split(strings.TrimSpace(string(out)), "\n") {

--- a/cmd/irgo/tools_doctor_locators_test.go
+++ b/cmd/irgo/tools_doctor_locators_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestEveryToolIrgoRunsIsLocated — doctor is how a developer finds out where
+// everything on their machine is. A tool the CLI runs but doctor never names
+// is one nobody can locate when a build picks up the wrong copy.
+func TestEveryToolIrgoRunsIsLocated(t *testing.T) {
+	located := map[string]bool{}
+	for _, r := range toolLocators() {
+		located[r.name] = true
+	}
+
+	// Named differently by doctor than by the binary, on purpose: "jdk" is
+	// clearer than "java" next to the Android rows, and tailwindcss is
+	// installed under a versioned filename.
+	alias := map[string]string{"java": "jdk", "keytool": "jdk"}
+
+	for _, name := range toolsIrgoRuns() {
+		if a, ok := alias[name]; ok {
+			name = a
+		}
+		if !located[name] {
+			t.Errorf("irgo runs %s but doctor never says where it is", name)
+		}
+	}
+}
+
+// TestLocatedToolsResolveOrReportAbsent — a row must either carry a real path
+// or admit it has none. A path that does not exist is worse than a blank,
+// because it sends someone to look at a file that is not there.
+func TestLocatedToolsResolveOrReportAbsent(t *testing.T) {
+	for _, r := range toolLocators() {
+		if r.path == "" {
+			continue
+		}
+		if !strings.HasPrefix(r.path, "/") && !strings.Contains(r.path, ":\\") {
+			t.Errorf("%s has a relative path %q — doctor should report where it actually is", r.name, r.path)
+		}
+	}
+}
+
+// toolsIrgoRuns reads the binaries this package actually invokes, so the check
+// above compares doctor against the code rather than against another list.
+func toolsIrgoRuns() []string {
+	out, err := exec.Command("sh", "-c",
+		`grep -rhoE '(exec\.Command|LookPath)\("[a-zA-Z0-9_.-]+"' *.go | sed -E 's/.*\("//;s/"//' | sort -u`).Output()
+	if err != nil {
+		return nil
+	}
+	// Only the ones irgo is responsible for having. Host utilities like sudo,
+	// open or apt-get are not toolchain, and naming them would be noise.
+	want := map[string]bool{
+		"templ": true, "air": true, "gomobile": true, "gobind": true,
+		"node": true, "java": true, "keytool": true, "adb": true,
+		"sdkmanager": true, "avdmanager": true, "go": true, "git": true,
+		"sops": true, "xcrun": true, "xcodebuild": true, "codesign": true,
+		"security": true, "clang": true,
+	}
+	var names []string
+	for _, n := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if want[n] {
+			names = append(names, n)
+		}
+	}
+	return names
+}

--- a/cmd/irgo/tools_doctor_versions.go
+++ b/cmd/irgo/tools_doctor_versions.go
@@ -15,8 +15,76 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
+
+// Where a tool comes from. Constants because these were nine string literals
+// across two functions, and a wording change meant finding them all.
+const (
+	howGoInstall = "go install"
+	howDownload  = "downloaded by irgo"
+	howAndroid   = "Android SDK, by irgo"
+	howMise      = "mise, else downloaded by irgo"
+	howPlatform  = "provided by the platform"
+	howHostPkg   = "host package manager"
+	howOptional  = "optional — irgo uses it if present"
+	howPrereq    = "prerequisite — compiles irgo"
+)
+
+// sourceOf says where the copy on this machine actually came from.
+//
+// Two questions kept getting conflated. How irgo *would* install a tool is a
+// fact about irgo — miseSpec and goToolPkg answer it. How the copy that is
+// here *did* arrive is a fact about the machine, and irgo does not always know:
+// templ may be irgo's `go install` or the developer's.
+//
+// This answers the second, and asks the authority rather than reading the path.
+// mise is asked whether it owns the binary; a substring check called templ a
+// mise package because it sits in the bin directory of a Go that mise manages,
+// and `tools remove` then printed a `mise uninstall templ` that matched
+// nothing.
+func sourceOf(name, path string) string {
+	if path == "" {
+		return ""
+	}
+	// mise, asked directly: is this path inside an install it owns?
+	//
+	// Containment rather than equality: a row may hold the binary (node) or
+	// the directory (the JDK, which is a JAVA_HOME), and both live under the
+	// same install.
+	if spec, ok := miseSpecFor(name); ok {
+		if dir := miseInstallDir(spec); dir != "" && strings.HasPrefix(path, dir) {
+			return "mise"
+		}
+	}
+	switch {
+	case strings.HasPrefix(path, androidHome()):
+		return howAndroid
+	case strings.HasPrefix(path, irgoHome()):
+		return howDownload
+	case gobinDir() != "" && strings.HasPrefix(path, gobinDir()):
+		return howGoInstall
+	case goToolPkg(name) != "":
+		// irgo installs this with `go install`, and it is not a mise package,
+		// so wherever it landed that is how it got there.
+		return howGoInstall
+	}
+	return "yours"
+}
+
+// miseInstallDir is where mise put a spec, or "" if it does not have it.
+func miseInstallDir(spec string) string {
+	mise, ok := miseCmd()
+	if !ok {
+		return ""
+	}
+	out, err := exec.Command(mise, "where", spec).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
 
 // toolStatus is one row.
 type toolStatus struct {
@@ -24,7 +92,62 @@ type toolStatus struct {
 	path    string // where it is, "" when absent
 	have    string // version reported by the tool
 	want    string // version irgo pins
-	managed bool   // irgo installed it
+	managed bool   // irgo installed it, per the marker in ~/.irgo/tools
+	// ensure gets the tool when it is missing. nil means irgo cannot provide
+	// it — Xcode, a C compiler — and doctor says so rather than pretending.
+	ensure func() error
+	// how it is obtained, in a few words. Printed, because otherwise the only
+	// way to learn whether a tool comes from `go install`, a download or mise
+	// is to read the source — and reading the source is what doctor is for.
+	how string
+	// size on disk, for directories irgo owns. "" for everything else.
+	size string
+	// remove undoes the install, when irgo was the one that did it. nil means
+	// there is nothing of irgo's to take back.
+	remove func() error
+}
+
+// irgoDiskUse reports how much space a tool irgo installed is using.
+//
+// Only under irgoHome: measuring the platform's own directories would be slow
+// and none of irgo's business. Returns "" when there is nothing to say.
+func irgoDiskUse(path string) string {
+	if path == "" || !strings.HasPrefix(path, irgoHome()) {
+		return ""
+	}
+	// The tool's own directory, not the binary — except in ~/.irgo/bin, which
+	// holds one file per tool, so walking up there would report the whole
+	// directory as the size of each one. tailwindcss read 76 MB that way.
+	dir := path
+	if filepath.Dir(path) == irgoBinDir() {
+		if fi, err := os.Stat(path); err == nil {
+			return humanBytes(fi.Size())
+		}
+		return ""
+	}
+	for filepath.Dir(dir) != irgoHome() && filepath.Dir(dir) != "/" && dir != "" {
+		dir = filepath.Dir(dir)
+	}
+	var total int64
+	_ = filepath.Walk(dir, func(_ string, fi os.FileInfo, err error) error {
+		if err == nil && !fi.IsDir() {
+			total += fi.Size()
+		}
+		return nil
+	})
+	return humanBytes(total)
+}
+
+func humanBytes(n int64) string {
+	switch {
+	case n == 0:
+		return ""
+	case n > 1<<30:
+		return fmt.Sprintf("%.1f GB", float64(n)/(1<<30))
+	case n > 1<<20:
+		return fmt.Sprintf("%d MB", n/(1<<20))
+	}
+	return fmt.Sprintf("%d KB", n/(1<<10))
 }
 
 // installedVersion is the version irgo recorded when it installed the tool.
@@ -67,8 +190,13 @@ func wantedVersion(tool string) string {
 // goToolStatuses reports every Go tool irgo installs.
 func goToolStatuses() []toolStatus {
 	var out []toolStatus
-	for _, name := range []string{"templ", "air", "gomobile", "gobind"} {
-		st := toolStatus{name: name, want: wantedVersion(name), managed: toolInstalledByIrgo(name)}
+	for _, name := range goTools() {
+		tool := name
+		st := toolStatus{
+			name: name, want: wantedVersion(name), managed: toolInstalledByIrgo(name),
+			ensure: func() error { return ensureGoTool(tool) },
+			how:    howGoInstall,
+		}
 		if p, err := exec.LookPath(name); err == nil {
 			st.path = p
 			st.have = installedVersion(name)
@@ -78,32 +206,388 @@ func goToolStatuses() []toolStatus {
 	return out
 }
 
-// nodeStatus reports the Node irgo downloads for wrangler. It is 176 MB and
-// nothing mentioned it until `tools remove` listed it, which is a poor way to
-// discover a large download.
+// nodeStatus reports the Node used for wrangler. It is 176 MB when irgo has to
+// download one, and nothing mentioned it until `tools remove` listed it, which
+// is a poor way to discover a large download.
+//
+// Asks nodeBin rather than working the path out again. The copy that used to
+// live here searched in the opposite order — managed before PATH — and did not
+// know about node.exe, so doctor could name a Node that no build would use.
+// A tool's own file decides where it is; doctor reports what it says.
 func nodeStatus() toolStatus {
-	st := toolStatus{name: "node", want: pinNode, managed: toolInstalledByIrgo("node")}
-	bin := filepath.Join(managedNodeHome(), "bin", "node")
-	if !pathExists(bin) {
-		if p, err := exec.LookPath("node"); err == nil {
-			bin = p
-		} else {
+	st := toolStatus{
+		name: "node", want: pinNode, managed: toolInstalledByIrgo("node"),
+		ensure: func() error { _, err := nodeBin(true); return err },
+		how:    howMise,
+	}
+	bin, err := nodeBin(false)
+	if err != nil {
+		return st
+	}
+	st.path = bin
+	// node --version is reliable, unlike the Go tools'.
+	if out, err := exec.Command(bin, "--version").Output(); err == nil {
+		st.have = strings.TrimSpace(strings.TrimPrefix(string(out), "v"))
+	}
+	return st
+}
+
+// toolLocators is every external program irgo runs, and the code that already
+// knows where it is.
+//
+// Each entry calls the owning file's resolver rather than rebuilding a path.
+// doctor used to work out node's location itself and got it wrong two ways, so
+// it could name a binary no build would use. Nothing here derives anything: a
+// tool's own file decides, and doctor reports what it says.
+//
+// Every developer's machine answers "where is everything" with one command,
+// and adding a tool means adding one line.
+func toolLocators() []toolStatus {
+	sdk := androidHome()
+
+	// found reports a path when something is actually there, and how to get
+	// it when it is not.
+	found := func(name, path, how string, ensure func() error) toolStatus {
+		st := toolStatus{name: name, ensure: ensure, how: how}
+		if path == "" {
 			return st
 		}
+		if _, err := os.Stat(path); err != nil {
+			return st
+		}
+		st.path = path
+		return st
 	}
-	if nodeWorks(bin) {
-		st.path = bin
-		// node --version is reliable, unlike the Go tools'.
-		if out, err := exec.Command(bin, "--version").Output(); err == nil {
-			st.have = strings.TrimSpace(strings.TrimPrefix(string(out), "v"))
+	// onPath is for tools found by name. ensure may be nil: irgo cannot
+	// install Xcode or a system C compiler, and says so instead.
+	onPath := func(name, how string, ensure func() error) toolStatus {
+		st := toolStatus{name: name, ensure: ensure, how: how}
+		if p, err := exec.LookPath(name); err == nil && runs(p) {
+			st.path = p
+		}
+		return st
+	}
+
+	rows := append(goToolStatuses(), nodeStatus())
+
+	// Tools mise provides, resolved through mise rather than by name.
+	//
+	// sops was in the platform list, so doctor looked it up on PATH, found a
+	// shim that fails with "no version is set", and reported absent — while
+	// mise had the binary all along. A tool mise provides has to be asked of
+	// mise, like every other row here.
+	rows = append(rows, miseRow("sops"))
+
+	// Downloaded by irgo.
+	rows = append(rows,
+		found("tailwindcss", tailwindPath(), howDownload, func() error {
+			_, err := ensureTailwind()
+			return err
+		}),
+	)
+
+	// The Android toolchain, each from the function that owns it.
+	jdk, _ := detectJDK17(false)
+	androidTools := func() error { return ensureAndroidToolchain(false, "") }
+	rows = append(rows,
+		found("jdk", jdk, howDownload, func() error {
+			_, ok := detectJDK17(true)
+			if !ok {
+				return fmt.Errorf("could not install a JDK 17")
+			}
+			return nil
+		}),
+		found("sdkmanager", locateSdkmanager(sdk), howAndroid, androidTools),
+		found("avdmanager", locateAvdmanager(sdk), howAndroid, androidTools),
+		found("adb", adbBin(), howAndroid, androidTools),
+		found("emulator", emulatorBin(sdk), howAndroid, func() error { return ensureAndroidToolchain(true, "") }),
+		found("ndk", ndkDir(sdk), howAndroid, androidTools),
+	)
+
+	// Provided by the platform or the developer. irgo cannot install these,
+	// but where they are is exactly what someone debugging a build needs.
+	for _, name := range platformTools() {
+		rows = append(rows, onPath(name, platformHow(name), platformEnsure(name)))
+	}
+
+	pruneStaleMarkers(rows)
+
+	// Everything below needs the finished set, so it runs here rather than in
+	// whichever command happens to call this. An earlier version attached
+	// removal inside doctor's printer, so `tools remove` — which reads this
+	// function directly — found nothing removable at all.
+	for i := range rows {
+		// Where it actually came from beats where it would come from.
+		if src := sourceOf(rows[i].name, rows[i].path); src != "" {
+			rows[i].how = src
+		}
+		// Disk, for the things irgo put there: 485 MB of Node and JDK sat in
+		// ~/.irgo duplicating what mise had, and only du could tell you.
+		rows[i].size = irgoDiskUse(rows[i].path)
+		// The inverse of how it was installed.
+		attachRemove(&rows[i])
+		// Ask the tool itself when irgo has no marker for it.
+		if rows[i].have == "" {
+			rows[i].have = toolVersion(rows[i].path)
+		}
+	}
+	return rows
+}
+
+// pruneStaleMarkers drops records of tools that are no longer there.
+//
+// ~/.irgo/tools says what irgo installed, which is the only way to know that a
+// mise or GOBIN copy is irgo's rather than the developer's. Nothing swept it,
+// so it accumulated: a marker for node long after that directory was deleted,
+// and one for entr, a tool irgo no longer uses at all.
+//
+// A marker for something absent is not harmless. It is the thing `tools
+// remove` consults to decide what it may delete.
+func pruneStaleMarkers(rows []toolStatus) {
+	dir := irgoToolsDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	known := map[string]bool{}
+	for _, r := range rows {
+		if r.path != "" {
+			known[r.name] = true
+		}
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue // the mise markers, pruned by spec below
+		}
+		name := e.Name()
+		if known[name] || isHostPackage(name) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(dir, name))
+	}
+
+}
+
+// isHostPackage keeps markers for brew and apt packages, which are not tools
+// in the table and have no path to check.
+func isHostPackage(name string) bool {
+	for _, p := range hostPackageKeys() {
+		if p == name {
+			return true
+		}
+	}
+	return false
+}
+
+// runs reports whether a binary actually executes.
+//
+// Existing is not the same as working: a version manager's shim is a real file
+// that fails with "no version is set" when nothing selects one. doctor named
+// the sops shim as though a build could use it, which is the same mistake
+// nodeWorks was written to stop.
+func runs(path string) bool {
+	if path == "" {
+		return false
+	}
+	// Only shims are distrusted. Testing every binary was worse than the bug:
+	// go, codesign and security do not take --version, exited non-zero, and
+	// doctor called three working tools ABSENT.
+	if !strings.Contains(path, string(filepath.Separator)+"shims"+string(filepath.Separator)) {
+		return true
+	}
+	out, err := exec.Command(path, "--version").CombinedOutput()
+	if err == nil {
+		return true
+	}
+	// A shim with nothing selected says so, and cannot be used by a build.
+	return !strings.Contains(string(out), "No version is set")
+}
+
+// toolVersion asks a binary what it is.
+//
+// The marker irgo writes only exists for tools irgo installed, which after
+// mise took over most of them left fifteen of twenty-two rows blank. Running
+// the tool covers the rest — carefully, because air and gobind have no version
+// flag and their usage text contains a Go version that is not theirs.
+func toolVersion(path string) string {
+	if path == "" {
+		return ""
+	}
+	out, err := exec.Command(path, "--version").Output()
+	if err != nil {
+		return ""
+	}
+	// The first token shaped like a version, and nothing else. "tailwindcss
+	// v4.3.3" and "git version 2.51.0" both land here; a usage banner does not.
+	for _, field := range strings.Fields(string(out)) {
+		v := strings.TrimPrefix(strings.TrimSuffix(field, ","), "v")
+		if versionShaped(v) {
+			return v
+		}
+	}
+	return ""
+}
+
+// versionShaped is a digit, a dot, a digit — deliberately strict, so a path or
+// a date does not read as a version.
+func versionShaped(s string) bool {
+	dots, digits := 0, 0
+	for _, r := range s {
+		switch {
+		case r == '.':
+			dots++
+		case r >= '0' && r <= '9':
+			digits++
+		case r == '-' || r == '+' || (r >= 'a' && r <= 'z'):
+			// build metadata, allowed after the numbers
+		default:
+			return false
+		}
+	}
+	if dots < 1 || digits < 2 || s == "" || s[0] < '0' || s[0] > '9' {
+		return false
+	}
+	// A trailing dot is not a version: xcrun prints "xcrun version 72." and
+	// that read as 72.
+	return s[len(s)-1] != '.'
+}
+
+// attachRemove gives a row the inverse of how it was installed.
+//
+// Only what irgo installed: the markers decide. A mise tool is uninstalled by
+// the exact spec irgo asked for, never by name, so a developer's own version
+// is never a candidate.
+func attachRemove(r *toolStatus) {
+	name := r.name
+	if spec, ok := miseSpecFor(name); ok && installedViaMise(spec) {
+		r.remove = func() error {
+			mise, ok := miseCmd()
+			if !ok {
+				return fmt.Errorf("mise is gone, so %s cannot be uninstalled through it", name)
+			}
+			if err := exec.Command(mise, "uninstall", spec).Run(); err != nil {
+				return err
+			}
+			return nil
+		}
+		return
+	}
+	// irgo's own directories.
+	if r.path != "" && strings.HasPrefix(r.path, irgoHome()) {
+		dir := irgoOwnedDir(r.path)
+		r.remove = func() error {
+			if err := os.RemoveAll(dir); err != nil {
+				return err
+			}
+			clearToolMarker(name)
+			return nil
+		}
+		return
+	}
+	if toolInstalledByIrgo(name) && r.how == howGoInstall {
+		r.remove = func() error {
+			removeToolPath(name)
+			clearToolMarker(name)
+			return nil
+		}
+	}
+}
+
+// irgoOwnedDir is what removing a tool should delete: its own directory under
+// ~/.irgo, or the single file when it lives in ~/.irgo/bin.
+func irgoOwnedDir(path string) string {
+	if filepath.Dir(path) == irgoBinDir() {
+		return path
+	}
+	dir := path
+	for filepath.Dir(dir) != irgoHome() && filepath.Dir(dir) != "/" && dir != "" {
+		dir = filepath.Dir(dir)
+	}
+	return dir
+}
+
+// miseRow resolves a tool through mise, at irgo's pin.
+func miseRow(name string) toolStatus {
+	st := toolStatus{
+		name:   name,
+		how:    howGoInstall,
+		ensure: func() error { return ensureGoTool(name) },
+	}
+	spec, ok := miseSpec(name)
+	if !ok {
+		return st
+	}
+	if mise, have := miseCmd(); have {
+		st.path = miseWhere(mise, spec, name)
+	}
+	if st.path == "" {
+		// Not through mise: whatever is on PATH, if it runs.
+		if p, err := exec.LookPath(name); err == nil && runs(p) {
+			st.path = p
 		}
 	}
 	return st
 }
 
+// platformHow says where a host tool comes from.
+func platformHow(name string) string {
+	switch name {
+	case "sops":
+		return howGoInstall
+	case "gcc", "pkg-config", "x86_64-w64-mingw32-gcc":
+		return howHostPkg
+	case "mise":
+		return howDownload
+	case "go":
+		return howPrereq
+	}
+	return howPlatform
+}
+
+// platformEnsure returns how to obtain a host tool, or nil when irgo cannot.
+//
+// sops is a Go program, so `go install` reaches it. The rest — Xcode, a C
+// compiler, git — come from the platform, and claiming otherwise would send
+// someone to run a command that cannot work.
+func platformEnsure(name string) func() error {
+	switch name {
+	case "mise":
+		return func() error { _, err := ensureMise(); return err }
+	case "sops":
+		return func() error { return ensureGoTool("sops") }
+	case "gcc", "pkg-config":
+		return func() error { return ensureOSPackage(name) }
+	case "x86_64-w64-mingw32-gcc":
+		return func() error { return ensureOSPackage("mingw-w64") }
+	}
+	return nil
+}
+
+// platformTools are the host programs irgo runs but does not provide. Listed
+// per OS, because naming xcrun on Linux would report a permanent absence.
+func platformTools() []string {
+	// mise first: on a machine that uses it, most rows above resolve to a
+	// path inside its installs directory, so it is the tool that explains
+	// where the others came from.
+	common := []string{"mise", "go", "git"}
+	switch runtime.GOOS {
+	case "darwin":
+		// mingw is the Windows cross-compiler. `tools remove` offered it back
+		// while doctor never mentioned it, so the only way to learn irgo had
+		// installed it was to try deleting things.
+		return append(common, "xcrun", "xcodebuild", "codesign", "security",
+			"clang", "x86_64-w64-mingw32-gcc")
+	case "linux":
+		return append(common, "gcc", "pkg-config", "x86_64-w64-mingw32-gcc")
+	case "windows":
+		return append(common, "powershell")
+	}
+	return common
+}
+
 // printToolVersions writes the section.
 func printToolVersions() {
-	rows := append(goToolStatuses(), nodeStatus())
+	rows := toolLocators()
 
 	w := 0
 	for _, r := range rows {
@@ -112,23 +596,42 @@ func printToolVersions() {
 		}
 	}
 
+	// Width for the "how" column too, so the three read as columns.
+	hw := 0
+	for _, r := range rows {
+		if len(r.how) > hw {
+			hw = len(r.how)
+		}
+	}
+
 	fmt.Println()
-	fmt.Println("Tools irgo installs:")
+	fmt.Println("Tools — where they are, and where they come from:")
 	var drifted []string
 	for _, r := range rows {
-		switch {
-		case r.path == "":
-			fmt.Printf("  %-*s  %-12s  installed when a build needs it\n", w, r.name, "absent")
-		case r.have == "":
-			// Present but not installed by irgo, so there is no record of what
-			// it is and no honest claim to make about it.
-			fmt.Printf("  %-*s  %-12s  %s\n", w, r.name, "yours", r.path)
-		case r.want != "" && !versionMatches(r.have, r.want):
-			fmt.Printf("  %-*s  %-12s  irgo pins %s\n", w, r.name, r.have, r.want)
-			drifted = append(drifted, r.name)
-		default:
-			fmt.Printf("  %-*s  %-12s  %s\n", w, r.name, r.have, whose(r))
+		// One line, one format. Five near-identical Printf calls differed only
+		// in the last two columns, which is how the path came to be missing
+		// from one of them.
+		// One meaning per column: what it is, where it came from, which
+		// version, where it lives. The version column used to say "yours",
+		// which after the source column became derived was the same word
+		// twice and a version nowhere.
+		state, note := r.have, r.path
+		if state == "" {
+			state = "-"
 		}
+		switch {
+		case r.path == "" && r.ensure == nil:
+			state, note = "-", "ABSENT — install it yourself"
+		case r.path == "":
+			state, note = "-", "absent — arrives when a build needs it"
+		case r.want != "" && r.have != "" && !versionMatches(r.have, r.want):
+			note = r.path + " — irgo pins " + r.want
+			drifted = append(drifted, r.name)
+		}
+		if r.size != "" {
+			note = r.size + "  " + note
+		}
+		fmt.Printf("  %-*s  %-*s  %-12s  %s\n", w, r.name, hw, r.how, state, note)
 	}
 
 	if len(drifted) > 0 {
@@ -154,13 +657,4 @@ func versionMatches(have, want string) bool {
 		return true
 	}
 	return false
-}
-
-// whose says where a tool came from, because "irgo installed this" and "you
-// installed this" have different consequences for `tools remove`.
-func whose(r toolStatus) string {
-	if r.managed {
-		return "installed by irgo"
-	}
-	return r.path
 }

--- a/cmd/irgo/tools_ensure_test.go
+++ b/cmd/irgo/tools_ensure_test.go
@@ -83,9 +83,11 @@ func TestRemovalCoversWhatIrgoInstalled(t *testing.T) {
 			t.Errorf("%s is in %s but nothing offers to remove it", row.name, irgoHome())
 		}
 	}
-	if removable == 0 {
-		t.Error("nothing at all is removable, which cannot be right on a machine irgo has built on")
-	}
+	// Nothing removable is the correct answer on a machine irgo has never
+	// installed anything on — a fresh CI runner, for one. The invariant is
+	// that what irgo installed is offered back, which the loop above checks;
+	// asserting a non-zero count assumed a developer's machine and failed
+	// everywhere else.
 	t.Logf("%d tools removable", removable)
 }
 

--- a/cmd/irgo/tools_ensure_test.go
+++ b/cmd/irgo/tools_ensure_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestEveryToolCanBeObtainedOrSaysWhyNot — the whole ensure idea is that a
+// call needing a tool gets one. A row with no path and no way to get it is a
+// dead end someone hits mid-build with nothing to do about it.
+//
+// go is the exception on purpose: it compiles the CLI, so it is there before
+// irgo runs at all. CI installs it the same way.
+func TestEveryToolCanBeObtainedOrSaysWhyNot(t *testing.T) {
+	provided := map[string]string{
+		"go":         "compiles irgo itself, so it is a prerequisite",
+		"git":        "ships with the platform's developer tools",
+		"mise":       "optional; irgo uses what it finds",
+		"xcrun":      "part of Xcode, which only Apple can install",
+		"xcodebuild": "part of Xcode",
+		"codesign":   "part of Xcode",
+		"security":   "part of macOS",
+		"clang":      "part of the Xcode command line tools",
+		"powershell": "part of Windows",
+	}
+	for _, row := range toolLocators() {
+		if row.ensure != nil {
+			continue
+		}
+		if _, ok := provided[row.name]; !ok {
+			t.Errorf("%s has no ensure function and no recorded reason — "+
+				"either give it one, or record why irgo cannot provide it", row.name)
+		}
+	}
+}
+
+// TestInstallableToolsAreReportedByDoctor — install and doctor read the same
+// table, so a tool cannot be installable without being visible.
+func TestInstallableToolsAreReportedByDoctor(t *testing.T) {
+	rows := toolLocators()
+	if len(rows) < 15 {
+		t.Fatalf("doctor reports %d tools — it used to be five, and the point was to cover them all", len(rows))
+	}
+	var installable int
+	for _, r := range rows {
+		if r.ensure != nil {
+			installable++
+		}
+	}
+	if installable == 0 {
+		t.Fatal("no tool can be installed, which cannot be right")
+	}
+	t.Logf("%d tools reported, %d of them irgo can install", len(rows), installable)
+}
+
+// TestEveryToolSaysWhereItComesFrom — doctor exists so nobody has to read the
+// source to learn how a tool arrives. A blank column sends them back to it.
+func TestEveryToolSaysWhereItComesFrom(t *testing.T) {
+	for _, row := range toolLocators() {
+		if row.how == "" {
+			t.Errorf("%s does not say where it comes from", row.name)
+		}
+	}
+}
+
+// TestRemovalCoversWhatIrgoInstalled — install and remove read the same table,
+// so anything irgo put on the machine has to be offered back. The first
+// version of this attached removal inside doctor's printer, so `tools remove`
+// found nothing removable at all and would have left every download behind.
+func TestRemovalCoversWhatIrgoInstalled(t *testing.T) {
+	var removable int
+	for _, row := range toolLocators() {
+		if row.remove != nil {
+			removable++
+		}
+		// A row irgo can install, that is present, and that lives somewhere
+		// irgo owns, must be removable.
+		if row.ensure != nil && row.path != "" &&
+			strings.HasPrefix(row.path, irgoHome()) && row.remove == nil {
+			t.Errorf("%s is in %s but nothing offers to remove it", row.name, irgoHome())
+		}
+	}
+	if removable == 0 {
+		t.Error("nothing at all is removable, which cannot be right on a machine irgo has built on")
+	}
+	t.Logf("%d tools removable", removable)
+}
+
+// TestABrokenShimIsNotReportedAsPresent — a version manager's shim is a real
+// file that fails with "no version is set" when nothing selects one. doctor
+// named the sops shim as a usable path, which is a build failure waiting in a
+// column that claims everything is fine.
+func TestABrokenShimIsNotReportedAsPresent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stub is POSIX")
+	}
+	dir := filepath.Join(t.TempDir(), "shims")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	broken := filepath.Join(dir, "sometool")
+	if err := os.WriteFile(broken,
+		[]byte("#!/bin/sh\necho 'mise ERROR No version is set for shim: sometool' >&2\nexit 1\n"),
+		0o755); err != nil {
+		t.Fatal(err)
+	}
+	if runs(broken) {
+		t.Error("a shim with no version selected was reported as usable")
+	}
+
+	working := filepath.Join(dir, "goodtool")
+	if err := os.WriteFile(working, []byte("#!/bin/sh\necho v1.2.3\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !runs(working) {
+		t.Error("a working shim was rejected")
+	}
+
+	// Everything outside a shims directory is trusted: go, codesign and
+	// security do not take --version, and testing them called three working
+	// tools absent.
+	if !runs("/usr/bin/codesign") {
+		t.Error("a real binary that does not take --version was rejected")
+	}
+}
+
+// TestVersionParsingRejectsJunk — "xcrun version 72." read as 72.
+func TestVersionParsingRejectsJunk(t *testing.T) {
+	for _, bad := range []string{"72.", "", "abc", "/usr/bin/x", "1", "2026-08-07"} {
+		if versionShaped(bad) {
+			t.Errorf("%q read as a version", bad)
+		}
+	}
+	for _, good := range []string{"4.3.3", "22.14.0", "0.3.977", "1.0.41", "2026.8.1"} {
+		if !versionShaped(good) {
+			t.Errorf("%q did not read as a version", good)
+		}
+	}
+}

--- a/cmd/irgo/tools_host_packages.go
+++ b/cmd/irgo/tools_host_packages.go
@@ -90,6 +90,17 @@ func (p osPackage) pkgNameFor(mgr string) string {
 	return ""
 }
 
+// hostPackageKeys names every package irgo can install through the host's
+// package manager. Their markers have no path to check, so marker pruning
+// needs to know them by name.
+func hostPackageKeys() []string {
+	var out []string
+	for _, p := range osPackages() {
+		out = append(out, p.key)
+	}
+	return out
+}
+
 func findOSPackage(key string) (osPackage, bool) {
 	for _, p := range osPackages() {
 		if p.key == key {

--- a/cmd/irgo/tools_mise.go
+++ b/cmd/irgo/tools_mise.go
@@ -1,0 +1,205 @@
+// mise, asked first when irgo has to install something.
+//
+// irgo downloaded 176 MB of Node and 309 MB of JDK onto a machine whose mise
+// already had both. That is the disruptive way round: a second copy of a
+// toolchain, in a directory only irgo knows about, that the developer's own
+// version manager cannot see or clean up.
+//
+// So when a tool is missing and mise can provide it, mise does. irgo's own
+// downloader stays as the fallback, because mise cannot reach everything —
+// templ and gomobile are `go install`, tailwindcss is not in the registry, and
+// the Android NDK needs the exact pin irgo holds rather than whatever a plugin
+// resolves to.
+//
+// Two rules:
+//
+//   - Never install a second mise. A host that has one keeps it — PATH, then
+//     mise's own install location, then irgo's, before anything is fetched.
+//     When a tool's install path goes through mise and the host has none, one
+//     static binary is downloaded: at that point mise is not optional, it is
+//     what stands between the developer and a working build.
+//   - Never touch the user's config. `mise use -g` rewrites config.toml.
+//     `mise install` plus `mise where` gets the same binary and leaves it alone.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// pinMise is bootstrapped only when a tool needs mise and the host has none.
+// irgo never upgrades a mise it did not install.
+const pinMise = "v2026.8.2"
+
+// ensureMise finds mise, or installs one.
+//
+// Called when a tool's install path goes through mise: at that point mise is
+// not optional, it is the thing standing between the developer and a working
+// build. Downloading one static binary is a smaller imposition than failing.
+//
+// A host that already has mise keeps it — three checks before anything is
+// fetched, so nobody ends up with two.
+func ensureMise() (string, error) {
+	if p, ok := miseCmd(); ok {
+		return p, nil
+	}
+	bin := filepath.Join(irgoBinDir(), "mise")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	asset, err := miseAsset()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		return "", err
+	}
+	fmt.Printf("mise not found — downloading %s...\n", pinMise)
+
+	// To .part then rename, so an interrupted download cannot leave something
+	// that later looks installed. Same as Tailwind's.
+	tmp := bin + ".part"
+	if err := downloadFile("https://github.com/jdx/mise/releases/download/"+pinMise+"/"+asset, tmp); err != nil {
+		os.Remove(tmp)
+		return "", fmt.Errorf("downloading mise: %w", err)
+	}
+	if err := os.Chmod(tmp, 0o755); err != nil {
+		os.Remove(tmp)
+		return "", err
+	}
+	if err := os.Rename(tmp, bin); err != nil {
+		os.Remove(tmp)
+		return "", err
+	}
+	markToolInstalled("mise")
+	return bin, nil
+}
+
+// miseAsset maps the host to a release asset. mise publishes bare binaries
+// beside the archives, so there is nothing to extract.
+func miseAsset() (string, error) {
+	var host, arch string
+	switch runtime.GOOS {
+	case "darwin":
+		host = "macos"
+	case "linux":
+		host = "linux"
+	case "windows":
+		return "mise-" + pinMise + "-windows-x64.exe", nil
+	default:
+		return "", fmt.Errorf("no mise build for %s", runtime.GOOS)
+	}
+	switch runtime.GOARCH {
+	case "arm64":
+		arch = "arm64"
+	case "amd64":
+		arch = "x64"
+	default:
+		return "", fmt.Errorf("no mise build for %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+	return fmt.Sprintf("mise-%s-%s-%s", pinMise, host, arch), nil
+}
+
+// miseCmd returns mise if this machine already has it, without installing.
+func miseCmd() (string, bool) {
+	if p, err := exec.LookPath("mise"); err == nil {
+		return p, true
+	}
+	// mise's own installer puts it here, and it is not always on PATH.
+	p := filepath.Join(homeDir(), ".local", "bin", "mise")
+	if pathExists(p) {
+		return p, true
+	}
+	return "", false
+}
+
+// miseTool returns a tool's binary from mise, installing it if mise can.
+//
+// spec is what mise is asked for, with irgo's pin in it — "node@22.14.0",
+// "aqua:tailwindlabs/tailwindcss@4.3.3". Returns "" when mise cannot provide
+// it, which is the caller's signal to fall back to irgo's own download.
+func miseTool(spec, binary string) string {
+	// Installing, not looking: mise is required here, so fetch one if needed.
+	mise, err := ensureMise()
+	if err != nil {
+		return ""
+	}
+	// Already installed: no network, no output, just a path.
+	if p := miseWhere(mise, spec, binary); p != "" {
+		return p
+	}
+	if err := exec.Command(mise, "install", spec).Run(); err != nil {
+		return ""
+	}
+	return miseWhere(mise, spec, binary)
+}
+
+// miseWhere asks where a version lives and finds the binary inside it.
+//
+// `mise where` reports an install directory without consulting or changing
+// which version is active, so this works whether or not the tool is in the
+// developer's config.
+//
+// The binary is searched for rather than assumed. Layouts differ — node uses
+// bin/, an aqua tool sits at the root, some nest a directory deep — and
+// hardcoding bin/ meant tailwindcss silently fell through to irgo's own
+// download while mise had it all along.
+func miseWhere(mise, spec, binary string) string {
+	out, err := exec.Command(mise, "where", spec).Output()
+	if err != nil {
+		return ""
+	}
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		return ""
+	}
+	if runtime.GOOS == "windows" && !strings.HasSuffix(binary, ".exe") {
+		binary += ".exe"
+	}
+	for _, p := range []string{
+		filepath.Join(dir, binary),
+		filepath.Join(dir, "bin", binary),
+	} {
+		if pathExists(p) {
+			return p
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		for _, p := range []string{
+			filepath.Join(dir, e.Name(), binary),
+			filepath.Join(dir, e.Name(), "bin", binary),
+		} {
+			if pathExists(p) {
+				return p
+			}
+		}
+	}
+	return ""
+}
+
+// installedViaMise reports whether the exact version irgo pins is installed.
+//
+// No bookkeeping: the pin is the identity. irgo only ever asks for
+// node@22.14.0, so that is the only node it can remove, and irgo's own source
+// says which one that is. A file recording "irgo installed this" only added
+// the distinction between installing a version and finding it already there —
+// and tools remove prints what it will delete and refuses without
+// confirmation, so a person sees node@22.14.0 before anything happens.
+func installedViaMise(spec string) bool {
+	mise, ok := miseCmd()
+	if !ok {
+		return false
+	}
+	return exec.Command(mise, "where", spec).Run() == nil
+}

--- a/cmd/irgo/tools_node.go
+++ b/cmd/irgo/tools_node.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -26,7 +27,7 @@ import (
 // failing because upstream moved.
 const pinNode = "22.14.0"
 
-func managedNodeHome() string { return filepath.Join(homeDir(), ".irgo", "node") }
+func managedNodeHome() string { return filepath.Join(irgoHome(), "node") }
 
 // nodeBin returns a usable node, provisioning one if needed.
 //
@@ -34,9 +35,24 @@ func managedNodeHome() string { return filepath.Join(homeDir(), ".irgo", "node")
 // that errors when no version is selected reports success to LookPath and then
 // fails, so it is tested rather than trusted.
 func nodeBin(install bool) (string, error) {
+	// The developer's own node, if it is new enough. Never replaced.
 	if p, err := exec.LookPath("node"); err == nil && nodeWorks(p) {
 		return p, nil
 	}
+
+	// mise before irgo's own copy. Every other tool resolves this way, and
+	// node did not only because it was wired first: it preferred ~/.irgo/node
+	// and so kept 165 MB alive that mise already had. Whichever is chosen
+	// here is the one doctor names, so the order is the answer to "which node
+	// is this build using".
+	if mise, ok := miseCmd(); ok {
+		for _, spec := range []string{"node@" + pinNode, "node"} {
+			if bin := miseWhere(mise, spec, "node"); nodeWorks(bin) {
+				return bin, nil
+			}
+		}
+	}
+
 	managed := filepath.Join(managedNodeHome(), "bin", "node")
 	if runtime.GOOS == "windows" {
 		managed = filepath.Join(managedNodeHome(), "node.exe")
@@ -44,25 +60,53 @@ func nodeBin(install bool) (string, error) {
 	if nodeWorks(managed) {
 		return managed, nil
 	}
+
 	if !install {
 		return "", fmt.Errorf("no working node found — irgo can install one into %s", managedNodeHome())
+	}
+	if bin := miseTool("node@"+pinNode, "node"); nodeWorks(bin) {
+		return bin, nil
 	}
 	return installNode()
 }
 
 // nodeWorks reports whether this binary actually runs.
 func nodeWorks(bin string) bool {
+	major, ok := nodeMajor(bin)
+	return ok && major >= minNodeMajor
+}
+
+// minNodeMajor is what wrangler 4 requires.
+//
+// A developer's own node is preferred, but "runs" is not the same as "works":
+// node 18 is still common, wrangler 4 refuses it, and the failure arrives from
+// inside npx looking like a Cloudflare problem. Too old is skipped here, so
+// irgo falls through to mise or its own copy — which leaves the developer's
+// node exactly where it was. irgo never replaces what is on the machine.
+const minNodeMajor = 20
+
+// nodeMajor runs a candidate and reports its major version.
+func nodeMajor(bin string) (int, bool) {
 	if bin == "" {
-		return false
+		return 0, false
 	}
 	if _, err := os.Stat(bin); err != nil {
-		return false
+		return 0, false
 	}
 	out, err := exec.Command(bin, "--version").CombinedOutput()
 	if err != nil {
-		return false
+		return 0, false
 	}
-	return strings.HasPrefix(strings.TrimSpace(string(out)), "v")
+	v := strings.TrimSpace(string(out))
+	if !strings.HasPrefix(v, "v") {
+		return 0, false
+	}
+	major, _, _ := strings.Cut(strings.TrimPrefix(v, "v"), ".")
+	n, err := strconv.Atoi(major)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 // installNode downloads Node into ~/.irgo/node.

--- a/cmd/irgo/tools_node_version_test.go
+++ b/cmd/irgo/tools_node_version_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestOldNodeIsSkippedNotUsed — a developer's own node is preferred, but node
+// 18 is still common and wrangler 4 refuses it. Taking it anyway produces a
+// failure from inside npx that reads like a Cloudflare problem.
+//
+// irgo must skip it and look elsewhere. It must never replace it: what is on
+// the machine is the developer's business.
+func TestOldNodeIsSkippedNotUsed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stub is POSIX")
+	}
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "node")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\necho v18.20.0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if major, ok := nodeMajor(fake); !ok || major != 18 {
+		t.Fatalf("nodeMajor read %d, %v — want 18", major, ok)
+	}
+	if nodeWorks(fake) {
+		t.Errorf("node 18 accepted; wrangler %d+ is required", minNodeMajor)
+	}
+
+	newer := filepath.Join(dir, "newnode")
+	if err := os.WriteFile(newer, []byte("#!/bin/sh\necho v22.14.0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !nodeWorks(newer) {
+		t.Error("node 22 rejected")
+	}
+}
+
+// TestNodeMajorHandlesJunk — a shim that prints an error, or nothing, must not
+// read as a usable node.
+func TestNodeMajorHandlesJunk(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stub is POSIX")
+	}
+	dir := t.TempDir()
+	for name, body := range map[string]string{
+		"empty":   "#!/bin/sh\n",
+		"noV":     "#!/bin/sh\necho 22.14.0\n",
+		"shimErr": "#!/bin/sh\necho 'no version set' >&2; exit 1\n",
+		"garbage": "#!/bin/sh\necho vBANANA\n",
+	} {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := nodeMajor(p); ok {
+			t.Errorf("%s was read as a usable node", name)
+		}
+	}
+	if _, ok := nodeMajor(filepath.Join(dir, "does-not-exist")); ok {
+		t.Error("a missing file was read as a usable node")
+	}
+}

--- a/cmd/irgo/tools_tailwind.go
+++ b/cmd/irgo/tools_tailwind.go
@@ -27,7 +27,23 @@ func tailwindBin() string {
 	if runtime.GOOS == "windows" {
 		name += ".exe"
 	}
-	return filepath.Join(homeDir(), ".irgo", "bin", name)
+	return filepath.Join(irgoBinDir(), name)
+}
+
+// tailwindPath finds an existing Tailwind without installing one.
+//
+// irgo's own copy, then mise's. doctor calls this, so it names the binary a
+// build would use — it was reporting "absent" while builds happily used the
+// one mise had, which is the gap this whole exercise kept turning up.
+func tailwindPath() string {
+	if fi, err := os.Stat(tailwindBin()); err == nil && fi.Mode()&0o111 != 0 {
+		return tailwindBin()
+	}
+	if mise, ok := miseCmd(); ok {
+		return miseWhere(mise, "aqua:tailwindlabs/tailwindcss@"+
+			strings.TrimPrefix(pinTailwind, "v"), "tailwindcss")
+	}
+	return ""
 }
 
 // tailwindAsset maps the host to a release asset name.
@@ -53,8 +69,15 @@ func tailwindAsset() (string, error) {
 // its path. Idempotent: the version is in the filename, so an upgrade fetches
 // a new file rather than silently replacing one that a build may be using.
 func ensureTailwind() (string, error) {
+	if bin := tailwindPath(); bin != "" {
+		return bin, nil
+	}
 	bin := tailwindBin()
-	if fi, err := os.Stat(bin); err == nil && fi.Mode()&0o111 != 0 {
+
+	// mise first, at irgo's pin. aqua has it, which the registry does not say
+	// because that listing is truncated.
+	if bin := miseTool("aqua:tailwindlabs/tailwindcss@"+strings.TrimPrefix(pinTailwind, "v"),
+		"tailwindcss"); bin != "" {
 		return bin, nil
 	}
 
@@ -92,7 +115,7 @@ func ensureTailwind() (string, error) {
 // removeTailwindPath removes the downloaded Tailwind binaries and returns the
 // last path removed, or "" when none were present.
 func removeTailwindPath() string {
-	dir := filepath.Join(homeDir(), ".irgo", "bin")
+	dir := irgoBinDir()
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return ""
@@ -113,7 +136,7 @@ func removeTailwindPath() string {
 
 // removeTailwind is the inverse, for uninstall-tools.
 func removeTailwind() bool {
-	dir := filepath.Join(homeDir(), ".irgo", "bin")
+	dir := irgoBinDir()
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return false


### PR DESCRIPTION
`doctor` derived what it knew from paths and guesses, `install` had its own list, and `remove` had a third. A tool could be reported present, installed again, and then not removable, because none of the three agreed on what irgo owns.

There is now one table. Each row knows the tool's name, where it is on this machine, where it came from, how to provision it, and how to remove it — `doctor` prints the table, `install` walks it, `remove` walks it. A tool added in one place is a tool all three commands know about.

Provisioning prefers **mise**, at irgo's pins. A developer who already has mise gets the version irgo wants without irgo touching their system; one who does not gets mise bootstrapped rather than a second copy of every toolchain in `~/.irgo`. That reclaimed 484MB on my machine — a node and a JDK irgo had downloaded alongside the ones mise already had.

Three bugs found on the way, each worth naming:

- The source column now asks mise where a tool lives instead of matching path prefixes. Prefix matching labelled `templ` a mise package because it sat in mise's Go bin directory, and printed four `mise uninstall` commands that would not have worked.
- Marker files are gone for mise-provided tools. The pin *is* the identity: if mise has `go@1.25.0` at irgo's pin, that is the proof. A marker was a second record of the same fact that could disagree with it.
- A binary that does not run is not a path. A broken shim reported `sops` as present until a build failed on it.

---

**Independent** — based directly on `main`, no dependencies. Builds and passes the full suite standalone. 12 files.

Second of five pieces splitting up #10.