### PR TITLE
feat(secrets): declare them once, and one registry for every setting

### DIFF
--- a/cmd/irgo/app_desktop_build.go
+++ b/cmd/irgo/app_desktop_build.go
@@ -441,3 +441,35 @@ func launchBuiltDesktop() error {
 	fmt.Printf("Launching %s...\n", path)
 	return runCommand(cmd[0], cmd[1:]...)
 }
+
+// androidPackageFromModulePath is bundleIDFromModulePath for Android, where
+// the rules are stricter.
+//
+// An Apple bundle ID may contain hyphens; an Android package name may not,
+// because each segment has to be a Java identifier. The two shared one
+// function, so any repository with a hyphen in its name — irgo-demo, and the
+// scaffolding derives from the module path — produced com.irgo.irgo-demo and
+// was told it was fine until Play rejected the upload.
+//
+// Hyphens become underscores rather than being dropped: com.irgo.irgo_demo
+// still reads as the project it came from, where com.irgo.irgodemo does not.
+// A segment starting with a digit gets a leading underscore for the same
+// reason — an identifier cannot start with one, and truncating loses meaning.
+func androidPackageFromModulePath(modulePath string) string {
+	parts := strings.Split(bundleIDFromModulePath(modulePath), ".")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.ToLower(strings.ReplaceAll(p, "-", "_"))
+		if p == "" {
+			continue
+		}
+		if p[0] >= '0' && p[0] <= '9' {
+			p = "_" + p
+		}
+		out = append(out, p)
+	}
+	if len(out) < 2 {
+		return "com.irgo.app"
+	}
+	return strings.Join(out, ".")
+}

--- a/cmd/irgo/app_package_config.go
+++ b/cmd/irgo/app_package_config.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 )
@@ -32,18 +34,6 @@ import (
 // > built-in default.
 // ---------------------------------------------------------------------------
 
-type configValue struct {
-	tomlSection string // toml section, e.g. "ios"
-	tomlKey     string // toml key, e.g. "team"
-	env         string // env var, e.g. "IRGO_IOS_TEAM"
-	flag        string // CLI flag, e.g. "--team"
-	display     string // human label, e.g. "Apple Team ID"
-	url         string // console page to open
-	how         string // click path / what it looks like
-	required    bool   // blocks packaging when unset
-	secret      bool   // never echo back (passwords/keys)
-}
-
 func appleDevURL(path string) string { return "https://developer.apple.com" + path }
 
 var (
@@ -56,81 +46,287 @@ var (
 	urlWinSDK        = "https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/"
 )
 
-// storeConfigValues returns every config value a store can consume, with the
-// metadata the wizard/checker needs. Optional values (defaults exist) are
-// marked required=false so packaging never blocks on them.
-func storeConfigValues(store string) []configValue {
-	switch store {
-	case "ios":
-		return []configValue{
-			{tomlSection: "ios", tomlKey: "team", env: "IRGO_IOS_TEAM", flag: "--team",
-				display: "Apple Team ID", url: urlASCMembership,
-				how: "Membership → Team ID (10-character ID)", required: true},
-		}
-	case "android":
-		return []configValue{
-			{tomlSection: "android", tomlKey: "keystore", env: "IRGO_ANDROID_KEYSTORE", flag: "--keystore",
-				display: "Signing keystore", url: urlPlayConsole,
-				how: "Debug keystore works by default (validation only). For release: keytool -genkey (see `irgo app package setup`); keep it safe — it can't change after first upload.", required: false},
-		}
-	case "windows":
-		return []configValue{
-			{tomlSection: "windows", tomlKey: "publisher", env: "IRGO_WINDOWS_PUBLISHER", flag: "--publisher",
-				display: "Publisher (CN=...)", url: urlPartnerCenter,
-				how: "Partner Center → your app → Product management → Product identity → Publisher display name. Empty = test-signed.", required: false},
-			{tomlSection: "windows", tomlKey: "cert", env: "IRGO_WINDOWS_CERT", flag: "--cert",
-				display: "Code-signing cert (PFX)", url: urlWinSDK,
-				how: "Optional real cert; empty = self-signed test cert (Store re-signs on upload).", required: false, secret: true},
-		}
-	case "macos":
-		return []configValue{
-			{tomlSection: "macos", tomlKey: "identity", env: "IRGO_MACOS_IDENTITY", flag: "--identity",
-				display: "Developer ID Application identity", url: urlASCCerts,
-				how: "Certificates → Developer ID Application → download + import to Keychain. Auto-picked from your Keychain if empty.", required: false},
-			{tomlSection: "macos", tomlKey: "notarize", env: "IRGO_MACOS_NOTARIZE", flag: "--notarize",
-				display: "Notarize?", url: "",
-				how: "Requires Apple ID + Team ID + an app-specific password (below).", required: false},
-			{tomlSection: "macos", tomlKey: "apple_id", env: "IRGO_APPLE_ID", flag: "--apple-id",
-				display: "Apple ID", url: urlAppleIDPass,
-				how: "Your Apple ID (for notarization).", required: false},
-			{tomlSection: "macos", tomlKey: "password", env: "IRGO_APPLE_PASSWORD", flag: "--password",
-				display: "App-specific password", url: urlAppleIDPass,
-				how: "appleid.apple.com → Sign-In & Security → App-Specific Passwords → generate one.", required: false, secret: true},
-		}
-	case "reviews-apple-ios", "reviews-apple-mac": // App Store review monitoring
-		appIDKey := "ios_app_id"
-		appIDEnv := "IRGO_IOS_APP_ID"
-		appIDDisplay := "iOS app numeric ID"
-		if store == "reviews-apple-mac" {
-			appIDKey = "mac_app_id"
-			appIDEnv = "IRGO_MAC_APP_ID"
-			appIDDisplay = "Mac app numeric ID"
-		}
-		return []configValue{
-			{tomlSection: "reviews", tomlKey: appIDKey, env: appIDEnv, flag: "",
-				display: appIDDisplay, url: "",
-				how: "From the app's App Store URL: apps.apple.com/app/id<THIS NUMBER>", required: true},
-			{tomlSection: "reviews", tomlKey: "ios_key_id", env: "IRGO_ASC_KEY_ID", flag: "",
-				display: "App Store Connect API Key ID", url: urlASCAPIKeys,
-				how: "App Store Connect → Users and Access → Integrations → API keys → generate (key needs Customer Reviews access). Key ID is 10 chars.", required: true},
-			{tomlSection: "reviews", tomlKey: "ios_issuer_id", env: "IRGO_ASC_ISSUER_ID", flag: "",
-				display: "App Store Connect API Issuer ID", url: urlASCAPIKeys,
-				how: "Same page — Issuer ID is a UUID.", required: true},
-			{tomlSection: "reviews", tomlKey: "ios_private_key", env: "IRGO_ASC_PRIVATE_KEY", flag: "",
-				display: "App Store Connect API private key (.p8)", url: urlASCAPIKeys,
-				how: "Download the .p8 when you create the key (downloadable once).", required: true, secret: true},
-		}
-	case "reviews-android":
-		return []configValue{
-			{tomlSection: "reviews", tomlKey: "android_package", env: "IRGO_ANDROID_PACKAGE", flag: "",
-				display: "Play package name", url: urlPlayConsole,
-				how: "Your Play package name, e.g. com.example.myapp", required: true},
-			{tomlSection: "reviews", tomlKey: "android_service_account", env: "IRGO_PLAY_SERVICE_ACCOUNT", flag: "",
-				display: "Play service-account JSON", url: urlPlayConsole,
-				how: "Google Play Console → Setup → API access → create service account → grant 'View app information'/'Reply to reviews' → download JSON.", required: true, secret: true},
+// A configValue is one setting this project can carry: where it sits in the
+// toml, the env var and flag that override it, what a human needs in order to
+// find it, which build targets need it, and — for the private ones — what it
+// is for.
+//
+// This is the only place a setting is declared. The struct field it lands in
+// is named here as an accessor, so parsing a file, reading a value, prompting
+// for it, checking it, and deciding where it may be copied are all projections
+// of one list.
+//
+// Each of those used to be its own switch statement. A setting added to three
+// of them and missed in the fourth read back empty, and nothing failed to
+// compile — which is how `android.key_alias` could be parsed but unreadable,
+// and how a signing credential could satisfy `secrets list` while `app package`
+// insisted it was missing.
+type configValue struct {
+	tomlSection string // toml section, e.g. "ios"
+	tomlKey     string // toml key, e.g. "team"
+	env         string // env var, e.g. "IRGO_IOS_TEAM"
+	flag        string // CLI flag, e.g. "--team"
+	display     string // human label, e.g. "Apple Team ID"
+	url         string // console page to open
+	how         string // click path / what it looks like
+	required    bool   // blocks packaging when unset
+	secret      bool   // never echo back (passwords/keys)
+	setup       bool   // `app package setup` walks a human through it
+
+	// pattern is what a valid value looks like, empty when anything goes.
+	// Checked before a build starts and before a value is pushed anywhere: a
+	// Team ID with a typo in it is otherwise found twenty minutes into a
+	// macOS runner, by codesign, in a message about provisioning profiles.
+	pattern string
+	// shape describes the pattern for a human, since a regexp does not.
+	shape string
+
+	// path marks a value that names a file rather than carrying its contents.
+	// CI has no filesystem to point at, so these travel as <ENV>_BASE64 and
+	// are written back out to a real file before a build looks for one.
+	path bool
+
+	// targets are the build targets that need this value. It is what makes
+	// the config per-app-type rather than one flat bag: `app package setup`
+	// asks only about the target being packaged, and `secrets list` can say
+	// which platform a credential is for.
+	targets []string
+
+	// role classifies the private ones, which decides where they may be
+	// copied. Only meaningful when secret.
+	role secretRole
+
+	// field is where the value lands in packageConfig. Exactly one of field
+	// or boolField is set for anything the toml carries; a value that lives
+	// only in the environment (a deploy token) has neither.
+	field     func(*packageConfig) *string
+	boolField func(*packageConfig) *bool
+}
+
+// The targets a value can belong to. Named rather than spelled inline so a
+// typo is a compile error instead of a setting that quietly belongs to no
+// target and is therefore never asked for.
+var (
+	forPackaging      = []string{"ios", "android", "windows", "macos"}
+	forIOS            = []string{"ios"}
+	forAndroid        = []string{"android"}
+	forWindows        = []string{"windows"}
+	forMacOS          = []string{"macos"}
+	forCloudflare     = []string{"cloudflare"}
+	forAppleReviews   = []string{"reviews-apple-ios", "reviews-apple-mac"}
+	forIOSReviews     = []string{"reviews-apple-ios"}
+	forMacReviews     = []string{"reviews-apple-mac"}
+	forAndroidReviews = []string{"reviews-android"}
+)
+
+// configStores is every target whose values irgo knows about, in the order a
+// human should see them. Its contents are checked against the registry by
+// test, so a target that gains a setting and is missed here is a failure
+// rather than a silently invisible store.
+var configStores = []string{"ios", "android", "windows", "macos", "cloudflare",
+	"reviews-apple-ios", "reviews-apple-mac", "reviews-android"}
+
+// configRegistry is every setting irgo understands.
+var configRegistry = []configValue{
+	// ---- common -----------------------------------------------------------
+	{tomlSection: "common", tomlKey: "version", env: "IRGO_VERSION", targets: forPackaging,
+		display: "Version", how: "Version string used as the Android versionName and the Windows version.",
+		field: func(c *packageConfig) *string { return &c.Version }},
+	{tomlSection: "common", tomlKey: "icon", env: "IRGO_ICON", targets: forPackaging,
+		display: "App icon", how: "One source icon, scaled for every store.",
+		field: func(c *packageConfig) *string { return &c.Icon }},
+
+	// ---- iOS --------------------------------------------------------------
+	{tomlSection: "ios", tomlKey: "team", env: "IRGO_IOS_TEAM", flag: "--team",
+		display: "Apple Team ID", url: urlASCMembership,
+		how:      "Membership → Team ID (10-character ID)",
+		required: true, setup: true, targets: forIOS,
+		pattern: `^[A-Z0-9]{10}$`, shape: "10 characters, letters and digits",
+		field: func(c *packageConfig) *string { return &c.IOSTeam }},
+	{tomlSection: "ios", tomlKey: "export_method", env: "IRGO_IOS_EXPORT_METHOD", targets: forIOS,
+		display: "Export method", how: "development, ad-hoc, app-store or enterprise.",
+		pattern: `^(development|ad-hoc|app-store|enterprise)$`, shape: "development, ad-hoc, app-store or enterprise",
+		field: func(c *packageConfig) *string { return &c.IOSExportMethod }},
+
+	// ---- Android ----------------------------------------------------------
+	{tomlSection: "android", tomlKey: "keystore", env: "IRGO_ANDROID_KEYSTORE", flag: "--keystore",
+		display: "Signing keystore", url: urlPlayConsole,
+		how:   "Debug keystore works by default (validation only). For release: keytool -genkey (see `irgo app package setup`); keep it safe — it can't change after first upload.",
+		setup: true, role: roleSigning, targets: forAndroid,
+		path:  true,
+		field: func(c *packageConfig) *string { return &c.AndroidKeystore }},
+	{tomlSection: "android", tomlKey: "keystore_pass", env: "IRGO_ANDROID_KEYSTORE_PASS", targets: forAndroid,
+		display: "Keystore password", secret: true, role: roleSigning,
+		field: func(c *packageConfig) *string { return &c.AndroidKeystorePw }},
+	{tomlSection: "android", tomlKey: "key_alias", env: "IRGO_ANDROID_KEY_ALIAS", targets: forAndroid,
+		display: "Key alias",
+		field:   func(c *packageConfig) *string { return &c.AndroidKeyAlias }},
+	{tomlSection: "android", tomlKey: "key_pass", env: "IRGO_ANDROID_KEY_PASS", targets: forAndroid,
+		display: "Key password", secret: true, role: roleSigning,
+		field: func(c *packageConfig) *string { return &c.AndroidKeyPass }},
+
+	// ---- Windows ----------------------------------------------------------
+	{tomlSection: "windows", tomlKey: "publisher", env: "IRGO_WINDOWS_PUBLISHER", flag: "--publisher",
+		display: "Publisher (CN=...)", url: urlPartnerCenter,
+		how:   "Partner Center → your app → Product management → Product identity → Publisher display name. Empty = test-signed.",
+		setup: true, targets: forWindows,
+		pattern: `^CN=`, shape: "starts with CN=",
+		field: func(c *packageConfig) *string { return &c.WindowsPublisher }},
+	{tomlSection: "windows", tomlKey: "cert", env: "IRGO_WINDOWS_CERT", flag: "--cert",
+		display: "Code-signing cert (PFX)", url: urlWinSDK,
+		how:   "Optional real cert; empty = self-signed test cert (Store re-signs on upload).",
+		setup: true, role: roleSigning, targets: forWindows,
+		path:  true,
+		field: func(c *packageConfig) *string { return &c.WindowsCert }},
+	{tomlSection: "windows", tomlKey: "cert_pass", env: "IRGO_WINDOWS_CERT_PASS", targets: forWindows,
+		display: "Cert password", secret: true, role: roleSigning,
+		field: func(c *packageConfig) *string { return &c.WindowsCertPass }},
+	{tomlSection: "windows", tomlKey: "icon", env: "IRGO_WINDOWS_ICON", targets: forWindows,
+		display: "Windows icon",
+		field:   func(c *packageConfig) *string { return &c.WindowsIcon }},
+
+	// ---- macOS ------------------------------------------------------------
+	{tomlSection: "macos", tomlKey: "identity", env: "IRGO_MACOS_IDENTITY", flag: "--identity",
+		display: "Developer ID Application identity", url: urlASCCerts,
+		how:   "Certificates → Developer ID Application → download + import to Keychain. Auto-picked from your Keychain if empty.",
+		setup: true, targets: forMacOS,
+		field: func(c *packageConfig) *string { return &c.MacIdentity }},
+	{tomlSection: "macos", tomlKey: "notarize", env: "IRGO_MACOS_NOTARIZE", flag: "--notarize",
+		display: "Notarize?",
+		how:     "Requires Apple ID + Team ID + an app-specific password (below).",
+		setup:   true, targets: forMacOS,
+		boolField: func(c *packageConfig) *bool { return &c.MacNotarize }},
+	{tomlSection: "macos", tomlKey: "apple_id", env: "IRGO_APPLE_ID", flag: "--apple-id",
+		display: "Apple ID", url: urlAppleIDPass,
+		how:   "Your Apple ID (for notarization).",
+		setup: true, targets: forMacOS,
+		field: func(c *packageConfig) *string { return &c.MacAppleID }},
+	{tomlSection: "macos", tomlKey: "team", env: "IRGO_MACOS_TEAM", targets: forMacOS,
+		display: "Team ID (notarization)",
+		field:   func(c *packageConfig) *string { return &c.MacTeam }},
+	{tomlSection: "macos", tomlKey: "password", env: "IRGO_APPLE_PASSWORD", flag: "--password",
+		display: "App-specific password", url: urlAppleIDPass,
+		how:   "appleid.apple.com → Sign-In & Security → App-Specific Passwords → generate one.",
+		setup: true, secret: true, role: roleSigning, targets: forMacOS,
+		field: func(c *packageConfig) *string { return &c.MacPassword }},
+	{tomlSection: "macos", tomlKey: "dmg", env: "IRGO_MACOS_DMG", targets: forMacOS,
+		display:   "Build a DMG?",
+		boolField: func(c *packageConfig) *bool { return &c.MacDMG }},
+
+	// ---- Cloudflare -------------------------------------------------------
+	//
+	// No toml field: these authenticate irgo itself, so they only ever come
+	// from the environment or the keychain. Declared here so that classifying
+	// them is a lookup rather than a guess at their name — `push` used to
+	// decide by string prefix, which is a heuristic standing in for a fact
+	// irgo already had.
+	{env: "CLOUDFLARE_API_TOKEN", display: "Cloudflare API token",
+		url:    "https://dash.cloudflare.com/profile/api-tokens",
+		how:    "My Profile → API Tokens → Create Token → Edit Cloudflare Workers.",
+		secret: true, role: roleDeploy, targets: forCloudflare},
+	{env: "CLOUDFLARE_ACCOUNT_ID", display: "Cloudflare account ID",
+		url:    "https://dash.cloudflare.com",
+		how:    "Workers & Pages → Account details → Account ID.",
+		secret: true, role: roleDeploy, targets: forCloudflare},
+
+	// ---- App Store review monitoring --------------------------------------
+	{tomlSection: "reviews", tomlKey: "ios_app_id", env: "IRGO_IOS_APP_ID",
+		display:  "iOS app numeric ID",
+		how:      "From the app's App Store URL: apps.apple.com/app/id<THIS NUMBER>",
+		required: true, setup: true, targets: forIOSReviews,
+		pattern: `^[0-9]+$`, shape: "digits only, from the App Store URL",
+		field: func(c *packageConfig) *string { return &c.ReviewsIOSAppID }},
+	{tomlSection: "reviews", tomlKey: "mac_app_id", env: "IRGO_MAC_APP_ID",
+		display:  "Mac app numeric ID",
+		how:      "From the app's App Store URL: apps.apple.com/app/id<THIS NUMBER>",
+		required: true, setup: true, targets: forMacReviews,
+		pattern: `^[0-9]+$`, shape: "digits only, from the App Store URL",
+		field: func(c *packageConfig) *string { return &c.ReviewsMacAppID }},
+	{tomlSection: "reviews", tomlKey: "ios_key_id", env: "IRGO_ASC_KEY_ID",
+		display: "App Store Connect API Key ID", url: urlASCAPIKeys,
+		how:      "App Store Connect → Users and Access → Integrations → API keys → generate (key needs Customer Reviews access). Key ID is 10 chars.",
+		required: true, setup: true, targets: forAppleReviews,
+		pattern: `^[A-Z0-9]{10}$`, shape: "10 characters, letters and digits",
+		field: func(c *packageConfig) *string { return &c.ReviewsIOSKeyID }},
+	{tomlSection: "reviews", tomlKey: "ios_issuer_id", env: "IRGO_ASC_ISSUER_ID",
+		display: "App Store Connect API Issuer ID", url: urlASCAPIKeys,
+		how:      "Same page — Issuer ID is a UUID.",
+		required: true, setup: true, targets: forAppleReviews,
+		pattern: `^[0-9a-fA-F-]{36}$`, shape: "a UUID",
+		field: func(c *packageConfig) *string { return &c.ReviewsIOSIssuerID }},
+	{tomlSection: "reviews", tomlKey: "ios_private_key", env: "IRGO_ASC_PRIVATE_KEY",
+		display: "App Store Connect API private key (.p8)", url: urlASCAPIKeys,
+		how:      "Download the .p8 when you create the key (downloadable once).",
+		required: true, setup: true, role: roleSigning, targets: forAppleReviews,
+		path:  true,
+		field: func(c *packageConfig) *string { return &c.ReviewsIOSPrivateKey }},
+	{tomlSection: "reviews", tomlKey: "android_package", env: "IRGO_ANDROID_PACKAGE",
+		display: "Play package name", url: urlPlayConsole,
+		how:      "Your Play package name, e.g. com.example.myapp",
+		required: true, setup: true, targets: forAndroidReviews,
+		pattern: `^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+$`, shape: "a reverse-domain name, e.g. com.example.myapp",
+		field: func(c *packageConfig) *string { return &c.ReviewsAndroidPackage }},
+	{tomlSection: "reviews", tomlKey: "android_service_account", env: "IRGO_PLAY_SERVICE_ACCOUNT",
+		display: "Play service-account JSON", url: urlPlayConsole,
+		how:      "Google Play Console → Setup → API access → create service account → grant 'View app information'/'Reply to reviews' → download JSON.",
+		required: true, setup: true, role: roleSigning, targets: forAndroidReviews,
+		path:  true,
+		field: func(c *packageConfig) *string { return &c.ReviewsAndroidServiceAcc }},
+}
+
+// sensitive reports whether what this setting carries has to be kept private.
+//
+// Two different things, which is why they are two flags:
+//
+//	secret — the value itself is private. A password, a token. It must never
+//	         be written to a committed file and must never be echoed back.
+//	path   — the value is a filename. The NAME is safe to commit and belongs
+//	         in the committed config; the FILE it points at is private, and
+//	         when it travels to CI it travels as contents — at which point it
+//	         is exactly as private as a secret.
+//
+// Conflating them was a real hole. android.keystore is a path and was not
+// marked secret, so classifying it fell through to "the app's own runtime
+// value", and `secrets push cloudflare` would have base64'd the Android
+// signing key into the Worker. That key cannot be reissued: lose control of it
+// and the app can never be updated on Play again.
+//
+// So classification, pushing and withholding ask this. Masking and which file
+// a value may be written to ask `secret` alone, because hiding a keystore's
+// path helps nobody and the path belongs in the committed config.
+func (cv configValue) sensitive() bool { return cv.secret || cv.path }
+
+// registryFor finds the setting a toml section and key name, nil when the file
+// carries something irgo does not understand.
+func registryFor(section, key string) *configValue {
+	for i := range configRegistry {
+		if configRegistry[i].tomlSection == section && configRegistry[i].tomlKey == key {
+			return &configRegistry[i]
 		}
 	}
 	return nil
+}
+
+// registryForEnv finds the setting an environment variable names.
+func registryForEnv(env string) *configValue {
+	for i := range configRegistry {
+		if configRegistry[i].env == env {
+			return &configRegistry[i]
+		}
+	}
+	return nil
+}
+
+// storeConfigValues returns the values `app package setup` walks a human
+// through for one target, in registry order.
+func storeConfigValues(store string) []configValue {
+	var out []configValue
+	for _, cv := range configRegistry {
+		if cv.setup && slices.Contains(cv.targets, store) {
+			out = append(out, cv)
+		}
+	}
+	return out
 }
 
 // valueFromEnv returns the value of an IRGO_* env var (the key itself).
@@ -144,35 +340,15 @@ func valueFromEnv(cv configValue) string {
 // valueFromConfig returns the value from irgo.package.toml ("" if absent).
 func valueFromConfig(cv configValue) string {
 	cfg := parsePackageConfig()
-	switch cv.tomlSection + "." + cv.tomlKey {
-	case "ios.team":
-		return cfg.IOSTeam
-	case "android.keystore":
-		return cfg.AndroidKeystore
-	case "windows.publisher":
-		return cfg.WindowsPublisher
-	case "windows.cert":
-		return cfg.WindowsCert
-	case "macos.identity":
-		return cfg.MacIdentity
-	case "macos.apple_id":
-		return cfg.MacAppleID
-	case "macos.password":
-		return cfg.MacPassword
-	case "reviews.ios_app_id":
-		return cfg.ReviewsIOSAppID
-	case "reviews.mac_app_id":
-		return cfg.ReviewsMacAppID
-	case "reviews.ios_key_id":
-		return cfg.ReviewsIOSKeyID
-	case "reviews.ios_issuer_id":
-		return cfg.ReviewsIOSIssuerID
-	case "reviews.ios_private_key":
-		return cfg.ReviewsIOSPrivateKey
-	case "reviews.android_package":
-		return cfg.ReviewsAndroidPackage
-	case "reviews.android_service_account":
-		return cfg.ReviewsAndroidServiceAcc
+	switch {
+	case cv.field != nil:
+		return *cv.field(&cfg)
+	case cv.boolField != nil:
+		// Empty rather than "false" when unset, so an unset flag still reads
+		// as "take the default" everywhere that tests a value for emptiness.
+		if *cv.boolField(&cfg) {
+			return "true"
+		}
 	}
 	return ""
 }
@@ -215,7 +391,7 @@ func deriveConfigValue(cv configValue) string {
 	}
 	if cv.tomlSection == "reviews" && cv.tomlKey == "android_package" {
 		if mp, err := getModulePath(); err == nil {
-			return bundleIDFromModulePath(mp)
+			return androidPackageFromModulePath(mp)
 		}
 	}
 	return ""
@@ -296,7 +472,7 @@ func runSetupWizard(store string, missing []configValue) error {
 		}
 		fmt.Printf("  %s", cv.display)
 		if cv.secret {
-			fmt.Print(" (input hidden? if not, fine — it goes into the gitignored toml)")
+			fmt.Printf(" (goes into %s, which is gitignored)", packageLocalFile)
 		}
 		fmt.Print(": ")
 		if !scanner.Scan() {
@@ -307,10 +483,14 @@ func runSetupWizard(store string, missing []configValue) error {
 			fmt.Printf("  (skipping %s)\n", cv.display)
 			continue
 		}
-		if err := writeConfigValue(cv.tomlSection, cv.tomlKey, val); err != nil {
+		if err := writeConfigValueFor(cv, val); err != nil {
 			return err
 		}
-		fmt.Printf("  ✓ wrote %s.%s\n", cv.tomlSection, cv.tomlKey)
+		dest := packageConfigFile
+		if cv.secret {
+			dest = packageLocalFile
+		}
+		fmt.Printf("  ✓ wrote %s.%s to %s\n", cv.tomlSection, cv.tomlKey, dest)
 	}
 	fmt.Println()
 	fmt.Println("Config updated. Run the command again and it should proceed.")
@@ -320,7 +500,28 @@ func runSetupWizard(store string, missing []configValue) error {
 // writeConfigValue sets a key in irgo.package.toml, preserving comments and
 // creating the section if needed.
 func writeConfigValue(section, key, value string) error {
-	lines, err := os.ReadFile(packageConfigFile)
+	return writeConfigValueTo(packageConfigFile, section, key, value)
+}
+
+// writeConfigValueFor writes a setting to whichever file may legitimately hold
+// it: a secret to the gitignored overlay, everything else to the committed
+// config.
+//
+// The wizard used to write everything to the committed file while telling you
+// it was doing the opposite — "it goes into the gitignored toml" — so running
+// `irgo app package setup macos` and answering the app-specific password
+// prompt put that password straight into a file destined for git.
+// `project config` had the same shape: it printed a note saying a secret
+// belongs in the local file, then wrote it to the committed one.
+func writeConfigValueFor(cv configValue, value string) error {
+	if cv.secret {
+		return writeConfigValueTo(packageLocalFile, cv.tomlSection, cv.tomlKey, value)
+	}
+	return writeConfigValueTo(packageConfigFile, cv.tomlSection, cv.tomlKey, value)
+}
+
+func writeConfigValueTo(file, section, key, value string) error {
+	lines, err := os.ReadFile(file)
 	if err != nil {
 		// A project generated before the config existed, or one where it was
 		// deleted, should still be able to record a setting rather than fail
@@ -329,8 +530,11 @@ func writeConfigValue(section, key, value string) error {
 			return err
 		}
 		seed := "# irgo app package configuration — see: irgo app package setup\n"
-		if werr := os.WriteFile(packageConfigFile, []byte(seed), 0o644); werr != nil {
-			return fmt.Errorf("creating %s: %w", packageConfigFile, werr)
+		if file == packageLocalFile {
+			seed = "# Secrets for this machine. Gitignored — never commit this file.\n"
+		}
+		if werr := os.WriteFile(file, []byte(seed), configPerm(file)); werr != nil {
+			return fmt.Errorf("creating %s: %w", file, werr)
 		}
 		lines = []byte(seed)
 	}
@@ -364,7 +568,16 @@ func writeConfigValue(section, key, value string) error {
 		}
 		text = append(text, fmt.Sprintf("%s = %q", key, value))
 	}
-	return os.WriteFile(packageConfigFile, []byte(strings.Join(text, "\n")), 0o644)
+	return os.WriteFile(file, []byte(strings.Join(text, "\n")), configPerm(file))
+}
+
+// configPerm keeps the secret overlay unreadable by anyone else on the
+// machine. The committed config holds nothing private, so it stays ordinary.
+func configPerm(file string) os.FileMode {
+	if file == packageLocalFile {
+		return 0o600
+	}
+	return 0o644
 }
 
 // ---------------------------------------------------------------------------
@@ -465,8 +678,16 @@ func checkStoreConfig(store string) {
 			label = "•••••• (set)"
 		}
 
+		// A value that is set but malformed is worse than one that is
+		// missing: it looks configured, and the tool that rejects it is
+		// several steps away and talking about something else.
+		invalid := validateConfigValue(cv, val)
+
 		status := "✓"
-		if val == "" {
+		switch {
+		case invalid != nil:
+			status = "!"
+		case val == "":
 			status = "✗"
 			if !cv.required {
 				status = "·" // optional: a default covers it
@@ -474,6 +695,13 @@ func checkStoreConfig(store string) {
 		}
 		fmt.Printf("  %s %-30s %-24s [%s]\n", status, cv.display, label, src)
 
+		if invalid != nil {
+			fmt.Printf("        problem:   %v\n", invalid)
+			if cv.how != "" {
+				fmt.Printf("                   %s\n", cv.how)
+			}
+			continue
+		}
 		if val != "" {
 			continue
 		}
@@ -554,4 +782,51 @@ func fileHasKey(path, section, key string) bool {
 		return strings.Trim(strings.TrimSpace(line[eq+1:]), `"'`) != ""
 	}
 	return false
+}
+
+// validateConfigValue checks a resolved value against what the setting says a
+// valid one looks like.
+//
+// The failure this prevents is expensive and confusing in equal measure: a
+// Team ID with a character missing is not rejected by anything until codesign
+// runs on a macOS runner, twenty minutes in, and what it says is that no
+// provisioning profile matches — which sends you looking at certificates.
+//
+// A value that is set but wrong is a different thing from one that is unset,
+// so this never reports on an empty value; that is what `required` is for.
+func validateConfigValue(cv configValue, value string) error {
+	if value == "" {
+		return nil
+	}
+	if cv.pattern != "" && !regexp.MustCompile(cv.pattern).MatchString(value) {
+		return fmt.Errorf("%q is not %s", value, cv.shape)
+	}
+	if cv.path {
+		// A path setting must hold a path. Key material pasted in here would
+		// be written to the committed config, which is the one place it must
+		// never go — and it would look like it had worked.
+		if strings.Contains(value, "-----BEGIN") || strings.ContainsAny(value, "\n\r") {
+			return fmt.Errorf("this is the contents of a key, not a path to one\n"+
+				"  put the file somewhere gitignored and name it here, or set %s%s in CI",
+				cv.env, base64Suffix)
+		}
+		// A path that is not there fails later as something less obvious — an
+		// empty keystore, or a signing step that quietly produces nothing.
+		if _, err := os.Stat(expandHome(value)); err != nil {
+			return fmt.Errorf("no file at %s", value)
+		}
+	}
+	return nil
+}
+
+// configProblems reports every setting for a target that is set but invalid.
+func configProblems(store string) map[string]error {
+	out := map[string]error{}
+	for _, cv := range storeConfigValues(store) {
+		val, _ := resolveConfigValue(cv)
+		if err := validateConfigValue(cv, val); err != nil {
+			out[cv.display] = err
+		}
+	}
+	return out
 }

--- a/cmd/irgo/app_package_config_test.go
+++ b/cmd/irgo/app_package_config_test.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The registry is the single declaration of every setting. These tests are
+// what make that true: without them "single declaration" is a comment, and the
+// four switch statements this replaced each drifted precisely because nothing
+// checked they agreed.
+
+// TestEverySettingRoundTrips writes each setting into a config file and reads
+// it back through the real resolver.
+//
+// This is the bug that kept happening: a setting was added to the parser and
+// missed in the reader, or the other way round, and it silently resolved to
+// empty. Nothing failed to compile, and packaging just behaved as though the
+// value had never been set.
+func TestEverySettingRoundTrips(t *testing.T) {
+	for _, cv := range configRegistry {
+		if cv.tomlSection == "" {
+			continue // environment-only, e.g. a deploy token
+		}
+		t.Run(cv.tomlSection+"."+cv.tomlKey, func(t *testing.T) {
+			want := "roundtrip-" + cv.tomlKey
+			if cv.boolField != nil {
+				want = "true"
+			}
+			inConfigDir(t, "["+cv.tomlSection+"]\n"+cv.tomlKey+" = \""+want+"\"\n")
+
+			if got := valueFromConfig(cv); got != want {
+				t.Errorf("wrote %s.%s = %q, read back %q\n"+
+					"the setting is declared but does not survive the file — "+
+					"check its field accessor in configRegistry",
+					cv.tomlSection, cv.tomlKey, want, got)
+			}
+		})
+	}
+}
+
+// TestEverySettingIsReachable checks the parts of an entry other code depends
+// on being there.
+func TestEverySettingIsReachable(t *testing.T) {
+	for _, cv := range configRegistry {
+		name := cv.tomlSection + "." + cv.tomlKey
+		if cv.tomlSection == "" {
+			name = cv.env
+		}
+
+		if cv.env == "" {
+			t.Errorf("%s: no env var, so it can never be supplied by CI", name)
+		}
+		if len(cv.targets) == 0 {
+			t.Errorf("%s: belongs to no target, so no command will ever ask for it", name)
+		}
+		if cv.display == "" {
+			t.Errorf("%s: no display name, so it renders blank in setup and doctor", name)
+		}
+		if cv.tomlSection != "" && cv.field == nil && cv.boolField == nil {
+			t.Errorf("%s: names a toml key with nowhere to put the value", name)
+		}
+		if cv.tomlSection == "" && (cv.field != nil || cv.boolField != nil) {
+			t.Errorf("%s: has a struct field but no toml key, so nothing can write it", name)
+		}
+	}
+}
+
+// TestEveryTargetIsListed keeps configStores honest. It decides display order
+// and what `secrets list` groups by, so a target that gains a setting and is
+// missed here is invisible rather than merely unsorted.
+func TestEveryTargetIsListed(t *testing.T) {
+	for _, cv := range configRegistry {
+		for _, target := range cv.targets {
+			if !slices.Contains(configStores, target) {
+				t.Errorf("%s.%s targets %q, which is not in configStores",
+					cv.tomlSection, cv.tomlKey, target)
+			}
+		}
+	}
+}
+
+// TestEnvVarsAreUnique guards the lookup classify and push depend on. Two
+// settings sharing an env var means one of them silently wins.
+func TestEnvVarsAreUnique(t *testing.T) {
+	seen := map[string]string{}
+	for _, cv := range configRegistry {
+		name := cv.tomlSection + "." + cv.tomlKey
+		if prev, dup := seen[cv.env]; dup {
+			t.Errorf("%s and %s both use %s", prev, name, cv.env)
+		}
+		seen[cv.env] = name
+	}
+}
+
+// TestSecretsAreClassified checks that every private value says what it is
+// for. The role decides whether `push cloudflare` will send it, so an
+// unclassified secret defaults to being treated as an app runtime value — and
+// a signing key would be copied into the Worker.
+func TestSecretsAreClassified(t *testing.T) {
+	for _, cv := range configRegistry {
+		if !cv.sensitive() {
+			continue
+		}
+		if cv.role == roleRuntime {
+			t.Errorf("%s is secret but unclassified, so push would send it to the Worker",
+				cv.env)
+		}
+		if role, _ := classify(cv.env); role != cv.role {
+			t.Errorf("%s: registry says %v, classify says %v", cv.env, cv.role, role)
+		}
+	}
+}
+
+// TestWorkerRejectsCredentialsItCannotUse is the rule that matters most: a
+// Worker holding the token that redeploys it turns one compromised Worker into
+// the whole account.
+func TestWorkerRejectsCredentialsItCannotUse(t *testing.T) {
+	for _, cv := range configRegistry {
+		if !cv.sensitive() {
+			continue
+		}
+		if withholdReason("cloudflare", cv.env) == "" {
+			t.Errorf("%s would be pushed into the Worker runtime", cv.env)
+		}
+		if withholdReason("github", cv.env) != "" {
+			t.Errorf("%s withheld from CI, which has to build and deploy", cv.env)
+		}
+	}
+	// An app's own secret is the one thing a Worker legitimately needs.
+	if why := withholdReason("cloudflare", "DATABASE_URL"); why != "" {
+		t.Errorf("app runtime secret withheld from the Worker: %s", why)
+	}
+}
+
+// inConfigDir runs the test in a temporary directory holding one config file,
+// since the config functions read from the working directory.
+func inConfigDir(t *testing.T, content string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, packageConfigFile), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(prev) })
+
+	// A stray IRGO_* in the developer's shell would otherwise decide the
+	// result, since the environment outranks the file.
+	for _, cv := range configRegistry {
+		if cv.env != "" && os.Getenv(cv.env) != "" && strings.HasPrefix(cv.env, "IRGO_") {
+			t.Setenv(cv.env, "")
+		}
+	}
+}
+
+// TestDerivedValuesAreValid is the test that would have caught the Android
+// package name: irgo derived com.irgo.irgo-demo from the module path and
+// reported it as configured, because nothing checked derived values against
+// the rules of the thing consuming them.
+//
+// Anything irgo works out for itself has to satisfy the same pattern a human
+// would be held to.
+func TestDerivedValuesAreValid(t *testing.T) {
+	modules := []string{
+		"github.com/joeblew999/irgo-demo", // the hyphen that started this
+		"github.com/example/myapp",
+		"example.com/2fast",  // a segment that cannot start a Java identifier
+		"myapp",              // bare module name
+		"github.com/a/b-c-d", // several hyphens
+	}
+	cv := *registryFor("reviews", "android_package")
+	for _, mp := range modules {
+		got := androidPackageFromModulePath(mp)
+		if err := validateConfigValue(cv, got); err != nil {
+			t.Errorf("module %q derived %q, which irgo would then reject: %v",
+				mp, got, err)
+		}
+	}
+}
+
+// TestValidationCatchesTypos checks the patterns actually discriminate. A
+// pattern that accepts everything is worse than none: it reads as a check.
+func TestValidationCatchesTypos(t *testing.T) {
+	cases := []struct {
+		section, key string
+		good, bad    string
+	}{
+		{"ios", "team", "9Z237BG9S9", "TOOSHORT"},
+		{"reviews", "ios_key_id", "ABCD123456", "abc"},
+		{"reviews", "ios_issuer_id", "69a6de70-1f2c-47e3-e053-5b8c7c11a4d1", "not-a-uuid"},
+		{"reviews", "ios_app_id", "1234567890", "id1234567890"},
+		{"reviews", "android_package", "com.example.myapp", "com.example.my-app"},
+		{"windows", "publisher", "CN=Example Ltd", "Example Ltd"},
+		{"ios", "export_method", "app-store", "appstore"},
+	}
+	for _, c := range cases {
+		cv := registryFor(c.section, c.key)
+		if cv == nil {
+			t.Errorf("%s.%s is not in the registry", c.section, c.key)
+			continue
+		}
+		if err := validateConfigValue(*cv, c.good); err != nil {
+			t.Errorf("%s.%s rejected a valid value %q: %v", c.section, c.key, c.good, err)
+		}
+		if err := validateConfigValue(*cv, c.bad); err == nil {
+			t.Errorf("%s.%s accepted %q", c.section, c.key, c.bad)
+		}
+	}
+}
+
+// An unset value is not an invalid one — that distinction is what `required`
+// carries, and conflating them makes every optional setting an error.
+func TestValidationIgnoresEmpty(t *testing.T) {
+	for _, cv := range configRegistry {
+		if err := validateConfigValue(cv, ""); err != nil {
+			t.Errorf("%s reported empty as invalid: %v", cv.env, err)
+		}
+	}
+}
+
+// TestSecretsNeverReachTheCommittedFile is the contradiction this config had
+// at its centre: irgo.package.toml is committed, and the wizard wrote every
+// answer into it — including the app-specific password it had just told you
+// was going somewhere gitignored.
+//
+// A test rather than care, because the write path is one function away from
+// every prompt, and the next setting added will not think about it.
+func TestSecretsNeverReachTheCommittedFile(t *testing.T) {
+	for _, cv := range configRegistry {
+		if cv.tomlSection == "" {
+			continue
+		}
+		t.Run(cv.tomlSection+"."+cv.tomlKey, func(t *testing.T) {
+			dir := t.TempDir()
+			prev, _ := os.Getwd()
+			if err := os.Chdir(dir); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { os.Chdir(prev) })
+
+			const canary = "S3CRET-CANARY"
+			if err := writeConfigValueFor(cv, canary); err != nil {
+				t.Fatal(err)
+			}
+
+			committed, _ := os.ReadFile(packageConfigFile)
+			local, _ := os.ReadFile(packageLocalFile)
+
+			if cv.secret {
+				if strings.Contains(string(committed), canary) {
+					t.Errorf("%s.%s is secret and was written to %s, which is committed",
+						cv.tomlSection, cv.tomlKey, packageConfigFile)
+				}
+				if !strings.Contains(string(local), canary) {
+					t.Errorf("%s.%s is secret but did not reach %s",
+						cv.tomlSection, cv.tomlKey, packageLocalFile)
+				}
+				if info, err := os.Stat(packageLocalFile); err == nil {
+					if perm := info.Mode().Perm(); perm != 0o600 {
+						t.Errorf("%s is %o, readable by others", packageLocalFile, perm)
+					}
+				}
+				return
+			}
+			if !strings.Contains(string(committed), canary) {
+				t.Errorf("%s.%s is not secret but did not reach %s",
+					cv.tomlSection, cv.tomlKey, packageConfigFile)
+			}
+		})
+	}
+}
+
+// TestTheLocalOverlayIsGitignored checks the assumption the whole split rests
+// on. A gitignored file that is not actually gitignored is worse than no
+// split at all, because everything downstream trusts it.
+func TestTheLocalOverlayIsGitignored(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("templates", ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), packageLocalFile) {
+		t.Errorf("scaffolded .gitignore does not list %s, so every secret the "+
+			"wizard writes would be committed", packageLocalFile)
+	}
+}
+
+// TestPathsAreTreatedAsCredentials. A path is not a secret — the name belongs
+// in the committed config — but the file it names is, and in CI it travels as
+// contents. Getting that wrong sent the Android signing keystore, which cannot
+// be reissued, into the Worker runtime.
+func TestPathsAreTreatedAsCredentials(t *testing.T) {
+	for _, cv := range configRegistry {
+		if !cv.path {
+			continue
+		}
+		if !cv.sensitive() {
+			t.Errorf("%s names a file but is not treated as sensitive", cv.env)
+		}
+		if cv.role == roleRuntime {
+			t.Errorf("%s names a credential file but is classified as app runtime", cv.env)
+		}
+		if withholdReason("cloudflare", cv.env) == "" {
+			t.Errorf("%s: the file it names would be pushed into the Worker", cv.env)
+		}
+		if cv.secret {
+			t.Errorf("%s is a path; marking it secret hides the filename for no gain "+
+				"and keeps it out of the committed config where it belongs", cv.env)
+		}
+	}
+}

--- a/cmd/irgo/ci_secrets_test.go
+++ b/cmd/irgo/ci_secrets_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The scaffolded workflows and the CLI have to agree on what a secret is
+// called, and for a long time they did not: the workflow read IOS_TEAM_ID
+// while irgo resolved IRGO_IOS_TEAM. Both halves looked right on their own.
+// `irgo secrets push github` dutifully set the repository secrets, every job
+// saw an empty string, and every job skipped itself — which is indistinguishable
+// from "not configured yet", so nothing ever complained.
+
+var secretRef = regexp.MustCompile(`secrets\.([A-Z0-9_]+)`)
+
+// TestWorkflowSecretsExist checks every secret the scaffolded workflows read
+// against the registry.
+func TestWorkflowSecretsExist(t *testing.T) {
+	for _, path := range workflowTemplates(t) {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		name := filepath.Base(path)
+		for _, m := range secretRef.FindAllStringSubmatch(string(data), -1) {
+			ref := m[1]
+			env := strings.TrimSuffix(ref, base64Suffix)
+
+			cv := registryForEnv(env)
+			if cv == nil {
+				t.Errorf("%s reads secrets.%s, which irgo does not resolve — "+
+					"`irgo secrets push github` will never set it", name, ref)
+				continue
+			}
+			// The base64 form is only meaningful for a value that names a
+			// file; asking for it on a plain string means the job reads a
+			// variable nothing ever sets.
+			if strings.HasSuffix(ref, base64Suffix) && !cv.path {
+				t.Errorf("%s reads secrets.%s, but %s carries a value, not a file",
+					name, ref, env)
+			}
+			if !strings.HasSuffix(ref, base64Suffix) && cv.path {
+				t.Errorf("%s reads secrets.%s, but %s names a file and has to "+
+					"travel as %s%s", name, ref, env, env, base64Suffix)
+			}
+		}
+	}
+}
+
+// TestWorkflowsPassNoSigningFlags keeps the workflows a mapping of names.
+//
+// irgo reads every setting from its own environment variable, so a flag in CI
+// is a second way to say the same thing — and the one that silently stops
+// matching when a flag is renamed.
+func TestWorkflowsPassNoSigningFlags(t *testing.T) {
+	flags := map[string]bool{}
+	for _, cv := range configRegistry {
+		if cv.flag != "" {
+			flags[cv.flag] = true
+		}
+	}
+	for _, path := range workflowTemplates(t) {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			if !strings.Contains(line, "irgo app package") {
+				continue
+			}
+			for flag := range flags {
+				if strings.Contains(line, flag+" ") {
+					t.Errorf("%s passes %s, which the env var already carries:\n  %s",
+						filepath.Base(path), flag, strings.TrimSpace(line))
+				}
+			}
+		}
+	}
+}
+
+func workflowTemplates(t *testing.T) []string {
+	t.Helper()
+	dir := filepath.Join("templates", "github", "workflows")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []string
+	for _, e := range entries {
+		out = append(out, filepath.Join(dir, e.Name()))
+	}
+	if len(out) == 0 {
+		t.Fatal("no workflow templates found")
+	}
+	return out
+}

--- a/cmd/irgo/cmd_app_build.go
+++ b/cmd/irgo/cmd_app_build.go
@@ -29,8 +29,10 @@ func runBuild(target string, sim, device bool, team string) error {
 
 	// _templ.go and output.css are generated and gitignored, yet the mobile
 	// package imports the former and every build embeds the latter. Regenerate
-	// both here rather than making callers remember the ordering.
-	if err := ensureAssets(); err != nil {
+	// both here rather than making callers remember the ordering — along with
+	// whatever the project generates for itself, which a build is the right
+	// moment for and a keystroke is not.
+	if err := ensureAssetsAndGenerate(); err != nil {
 		return err
 	}
 

--- a/cmd/irgo/cmd_app_package.go
+++ b/cmd/irgo/cmd_app_package.go
@@ -93,75 +93,15 @@ func parsePackageConfigFile(path string, cfg packageConfig) packageConfig {
 		}
 		key := strings.TrimSpace(line[:eq])
 		val := strings.Trim(strings.TrimSpace(line[eq+1:]), `"'`)
-		switch section {
-		case "common":
-			switch key {
-			case "version":
-				cfg.Version = val
-			case "icon":
-				cfg.Icon = val
-			}
-		case "ios":
-			switch key {
-			case "team":
-				cfg.IOSTeam = val
-			case "export_method":
-				cfg.IOSExportMethod = val
-			}
-		case "android":
-			switch key {
-			case "keystore":
-				cfg.AndroidKeystore = val
-			case "keystore_pass":
-				cfg.AndroidKeystorePw = val
-			case "key_alias":
-				cfg.AndroidKeyAlias = val
-			case "key_pass":
-				cfg.AndroidKeyPass = val
-			}
-		case "windows":
-			switch key {
-			case "publisher":
-				cfg.WindowsPublisher = val
-			case "cert":
-				cfg.WindowsCert = val
-			case "cert_pass":
-				cfg.WindowsCertPass = val
-			case "icon":
-				cfg.WindowsIcon = val
-			}
-		case "macos":
-			switch key {
-			case "identity":
-				cfg.MacIdentity = val
-			case "notarize":
-				cfg.MacNotarize = val == "true" || val == "1" || val == "yes"
-			case "apple_id":
-				cfg.MacAppleID = val
-			case "team":
-				cfg.MacTeam = val
-			case "password":
-				cfg.MacPassword = val
-			case "dmg":
-				cfg.MacDMG = val == "true" || val == "1" || val == "yes"
-			}
-		case "reviews":
-			switch key {
-			case "ios_app_id":
-				cfg.ReviewsIOSAppID = val
-			case "mac_app_id":
-				cfg.ReviewsMacAppID = val
-			case "ios_key_id":
-				cfg.ReviewsIOSKeyID = val
-			case "ios_issuer_id":
-				cfg.ReviewsIOSIssuerID = val
-			case "ios_private_key":
-				cfg.ReviewsIOSPrivateKey = val
-			case "android_package":
-				cfg.ReviewsAndroidPackage = val
-			case "android_service_account":
-				cfg.ReviewsAndroidServiceAcc = val
-			}
+		cv := registryFor(section, key)
+		if cv == nil {
+			continue // a key irgo does not know; leave it for whoever does
+		}
+		switch {
+		case cv.field != nil:
+			*cv.field(&cfg) = val
+		case cv.boolField != nil:
+			*cv.boolField(&cfg) = val == "true" || val == "1" || val == "yes"
 		}
 	}
 	return cfg
@@ -492,7 +432,7 @@ func packageCommand(args []string) error {
 			}
 		}
 		if check {
-			stores := []string{"ios", "android", "windows", "macos", "reviews-apple-ios", "reviews-apple-mac", "reviews-android"}
+			stores := configStores
 			if store != "" {
 				stores = []string{store}
 			}

--- a/cmd/irgo/cmd_project_config.go
+++ b/cmd/irgo/cmd_project_config.go
@@ -142,13 +142,22 @@ func setConfig(key, value string) error {
 			return err
 		}
 	}
-	if k.secret {
-		fmt.Printf("note: %s is a secret. %s is committed; put it in %s or set the\n"+
-			"      environment variable instead — see: irgo app package setup --check\n",
-			k.key, packageConfigFile, packageLocalFile)
+	cv := registryFor(k.section, k.name)
+	if cv == nil {
+		return unknownConfigKey(k.key)
 	}
-	if err := writeConfigValue(k.section, k.name, value); err != nil {
+	if err := validateConfigValue(*cv, value); err != nil {
+		return fmt.Errorf("%s: %w\n  %s", k.key, err, cv.how)
+	}
+	if err := writeConfigValueFor(*cv, value); err != nil {
 		return err
+	}
+	// A secret goes to the gitignored overlay and is not echoed back: this
+	// used to print the value and say it had gone somewhere it had not.
+	if cv.secret {
+		fmt.Printf("%s set  (%s, gitignored — not committed)\n", k.key, packageLocalFile)
+		fmt.Printf("  for CI, set %s there instead\n", cv.env)
+		return nil
 	}
 	fmt.Printf("%s = %q  (%s)\n", k.key, value, packageConfigFile)
 	return nil
@@ -233,7 +242,7 @@ func readConfigRaw(path, section, key string) string {
 // envForConfigKey maps a setting to the environment variable that overrides
 // it, which is what a CI secret has to be called.
 func envForConfigKey(key string) string {
-	for _, store := range []string{"ios", "android", "windows", "macos", "reviews-apple-ios", "reviews-android"} {
+	for _, store := range configStores {
 		for _, cv := range storeConfigValues(store) {
 			if cv.tomlSection+"."+cv.tomlKey == key {
 				return cv.env

--- a/cmd/irgo/cmd_project_new.go
+++ b/cmd/irgo/cmd_project_new.go
@@ -3,6 +3,7 @@ package main
 import (
 	"embed"
 	"fmt"
+	"github.com/stukennedy/irgo/pkg/secrets"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -323,6 +324,17 @@ func newProject(name string) error {
 		if strings.HasSuffix(path, "/"+packageConfigFile) || path == "templates/"+packageConfigFile {
 			if _, err := os.Stat(filepath.Join(projectDir, packageConfigFile)); err == nil {
 				fmt.Printf("  kept (yours): %s\n", packageConfigFile)
+				return nil
+			}
+		}
+
+		// fnox.toml names the secrets a project needs. Like irgo.package.toml
+		// it is a seed: once a project has declared what it uses, rewriting it
+		// would drop those declarations and the next deploy would fail looking
+		// for a token nothing asks for any more.
+		if strings.HasSuffix(path, "/"+secrets.ConfigName) || path == "templates/"+secrets.ConfigName {
+			if _, err := os.Stat(filepath.Join(projectDir, secrets.ConfigName)); err == nil {
+				fmt.Printf("  kept (yours): %s\n", secrets.ConfigName)
 				return nil
 			}
 		}

--- a/cmd/irgo/cmd_route.go
+++ b/cmd/irgo/cmd_route.go
@@ -33,6 +33,13 @@ func route(noun, verb string, args []string) (error, bool) {
 		return nil, true
 	}
 
+	// Secrets before anything reads config: both resolve through IRGO_* env
+	// vars, so the keychain has to be in the environment before the first
+	// lookup. After the --help guard, because asking what a command does
+	// should not unlock a keychain.
+	currentEnv = envFlag(args)
+	applySecrets()
+
 	switch noun {
 
 	case "project":
@@ -60,6 +67,8 @@ func route(noun, verb string, args []string) (error, bool) {
 			return runCI(hasFlag(args, "--force", "-f")), true
 		case "assets":
 			return ensureAssets(), true
+		case "generate":
+			return runGoGenerate(), true
 		case "test":
 			return runTest(), true
 		case "config":
@@ -100,6 +109,9 @@ func route(noun, verb string, args []string) (error, bool) {
 		case "reviews":
 			return reviewsCommand(args), true
 		}
+
+	case "secrets":
+		return runSecrets(append([]string{verb}, args...)), true
 
 	case "tools":
 		rest := args
@@ -155,6 +167,7 @@ var nounVerbs = map[string][]string{
 	"project": {"new", "clean", "upgrade", "pin", "ci", "assets", "test", "config"},
 	"app":     {"build", "run", "package", "deploy", "install", "remove", "reviews"},
 	"tools":   {"install", "remove", "doctor"},
+	"secrets": {"list", "status", "push"},
 	"server":  {"dev", "serve"},
 }
 

--- a/cmd/irgo/cmd_secrets.go
+++ b/cmd/irgo/cmd_secrets.go
@@ -1,0 +1,707 @@
+// `irgo secrets` — what this project needs, and getting it where it is needed.
+//
+// The secrets live in one place: the keychain, declared per repo in fnox.toml.
+// Everything else is a copy that has to be pushed there and kept in step —
+// GitHub Actions cannot read a laptop's keychain, and neither can a Cloudflare
+// Worker at runtime.
+//
+// Pushing was the missing half. Reading fnox got a deploy working from a
+// laptop; CI still needed someone to remember `gh secret set` for each name in
+// each repo, and nothing said when they had drifted.
+//
+// Values are never printed and never passed as arguments — both `gh secret
+// set` and `wrangler secret put` read from stdin, so a secret does not reach
+// the shell history, the process list, or this program's output.
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/stukennedy/irgo/pkg/secrets"
+)
+
+func runSecrets(args []string) error {
+	env := envFlag(args)
+	switch verb(args) {
+	case "list", "":
+		return secretsList(env)
+	case "status":
+		return secretsStatus(env)
+	case "push":
+		return secretsPush(args, env)
+	}
+	return fmt.Errorf("unknown: irgo secrets %s", verb(args))
+}
+
+// envFlag reads --env, falling back to IRGO_ENV.
+//
+// The variable matters more than the flag: a CI job sets it once for the whole
+// workflow, and every irgo command in that job then resolves the right values
+// without each step remembering to pass it.
+func envFlag(args []string) string {
+	for i, a := range args {
+		if v, ok := strings.CutPrefix(a, "--env="); ok {
+			return v
+		}
+		if a == "--env" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return os.Getenv("IRGO_ENV")
+}
+
+// verb is the first non-flag argument.
+func verb(args []string) string {
+	for _, a := range args {
+		if !strings.HasPrefix(a, "-") {
+			return a
+		}
+	}
+	return ""
+}
+
+// secretsList reports what this project declares and whether each resolves.
+//
+// Names and status only. A command that prints secret values is a command
+// someone will run in a shared terminal.
+func secretsList(env string) error {
+	cfg, ok, err := secrets.Load(".")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		fmt.Printf("No %s here — this project declares no secrets.\n", secrets.ConfigName)
+		return nil
+	}
+
+	if env != "" && !cfg.HasEnv(env) {
+		return fmt.Errorf("%s declares no environment %q%s", cfg.Path, env,
+			envHint(cfg))
+	}
+	_, skipped, err := secrets.Apply(".", env)
+	if err != nil {
+		return err
+	}
+	cfg = cfg.For(env)
+
+	w := 0
+	for _, sec := range cfg.Secrets {
+		if len(sec.Name) > w {
+			w = len(sec.Name)
+		}
+	}
+
+	// Grouped by what each is for. A flat list reads as though an Apple
+	// signing key and a database URL are the same kind of thing, and the
+	// whole point of the grouping is that they go to different places.
+	type row struct{ name, status string }
+	groups := map[string][]row{}
+	var order []string
+	for _, sec := range cfg.Secrets {
+		role, targets := classify(sec.Name)
+		head := role.String()
+		if len(targets) > 0 {
+			head += " — " + strings.Join(targets, ", ")
+		}
+		if _, seen := groups[head]; !seen {
+			order = append(order, head)
+		}
+		status := "ok        from " + sec.Provider
+		if skipped[sec.Name] != nil {
+			status = fmt.Sprintf("missing   %v", skipped[sec.Name])
+		}
+		groups[head] = append(groups[head], row{sec.Name, status})
+	}
+
+	head := "Declared in " + cfg.Path
+	if env != "" {
+		head += ", environment " + env
+	}
+	fmt.Println(head + ":")
+	for _, head := range order {
+		fmt.Printf("\n  %s\n", head)
+		for _, r := range groups[head] {
+			fmt.Printf("    %-*s  %s\n", w, r.name, r.status)
+		}
+	}
+	printKnownSecrets(cfg)
+
+	if len(cfg.EnvNames) > 0 {
+		fmt.Println()
+		fmt.Printf("Environments declared here: %s\n", strings.Join(cfg.EnvNames, ", "))
+		fmt.Println("  irgo secrets list --env " + cfg.EnvNames[0])
+	}
+
+	fmt.Println()
+	fmt.Println("Push them where they are also needed:")
+	fmt.Println("  irgo secrets push github      # GitHub Actions")
+	fmt.Println("  irgo secrets push cloudflare  # Worker runtime")
+	if len(cfg.EnvNames) > 0 {
+		fmt.Println("  ... --env " + cfg.EnvNames[0] + "     # that environment's values")
+	}
+	return nil
+}
+
+// envHint names what is actually declared, since a typo here is otherwise
+// indistinguishable from an environment nobody has set up yet.
+func envHint(cfg *secrets.Config) string {
+	if len(cfg.EnvNames) == 0 {
+		return " (none are)"
+	}
+	return " — declared: " + strings.Join(cfg.EnvNames, ", ")
+}
+
+// ---------------------------------------------------------------------------
+// What a secret is FOR, which decides where it may be copied.
+//
+// fnox.toml is a flat list of names, but the things it names are not alike. An
+// Apple signing key, a Cloudflare API token and the app's own database URL want
+// to end up in three different places, and copying any of them to the wrong one
+// is a real mistake — `push cloudflare` used to put the token that can redeploy
+// the Worker inside that same Worker.
+//
+// Rather than a second list saying which is which, this joins against the store
+// registry irgo already has: storeConfigValues knows every IRGO_* value, which
+// target needs it, and whether it is private. A declared secret that matches one
+// is that target's signing credential. Everything else is the app's own.
+// ---------------------------------------------------------------------------
+
+type secretRole int
+
+const (
+	roleRuntime secretRole = iota // the app needs it while running
+	roleDeploy                    // it performs a deploy
+	roleSigning                   // it signs a build for a store
+)
+
+// classify says what a declared secret is for, and which targets need it.
+//
+// A lookup in the registry, not a guess: irgo already knows every IRGO_* and
+// deploy credential, which target needs it and what it is for. This used to
+// match on a CLOUDFLARE_ name prefix, which is a heuristic standing in for a
+// fact already on hand — and one that quietly misfiled anything named
+// differently.
+//
+// A name the registry does not carry is the app's own runtime secret. irgo
+// cannot know a project's database URL, and should not pretend otherwise.
+func classify(name string) (secretRole, []string) {
+	if cv := registryForEnv(name); cv != nil && cv.sensitive() {
+		return cv.role, cv.targets
+	}
+	return roleRuntime, nil
+}
+
+func (r secretRole) String() string {
+	switch r {
+	case roleDeploy:
+		return "deploy credential"
+	case roleSigning:
+		return "signing credential"
+	}
+	return "app runtime"
+}
+
+// printKnownSecrets reports the credentials irgo knows about that this project
+// has not declared, grouped by the target that needs them.
+//
+// The registry already carries which values are private, what each is for and
+// which target needs it, because `app package setup` has to know not to echo a
+// password back. Nobody should have to copy that into fnox.toml by hand and
+// keep the two in step.
+//
+// Only what is missing is shown. A project that ships to one store should not
+// have to read about the other three.
+func printKnownSecrets(cfg *secrets.Config) {
+	declared := map[string]bool{}
+	for _, s := range cfg.Secrets {
+		declared[s.Name] = true
+	}
+
+	byTarget := map[string][]configValue{}
+	for _, cv := range configRegistry {
+		if !cv.sensitive() || cv.env == "" || declared[cv.env] {
+			continue
+		}
+		if os.Getenv(cv.env) != "" {
+			continue // supplied some other way, and irgo is not the boss of that
+		}
+		for _, t := range cv.targets {
+			byTarget[t] = append(byTarget[t], cv)
+		}
+	}
+	if len(byTarget) == 0 {
+		return
+	}
+
+	var first string
+	fmt.Println()
+	fmt.Println("Credentials irgo knows about, not declared here:")
+	for _, target := range configStores {
+		vals := byTarget[target]
+		if len(vals) == 0 {
+			continue
+		}
+		fmt.Printf("\n  %s\n", target)
+		for _, cv := range vals {
+			fmt.Printf("    %-28s %s\n", cv.env, cv.display)
+			if first == "" {
+				first = cv.env
+			}
+		}
+	}
+	fmt.Println()
+	fmt.Println("Only needed if this project ships to that target. To use one, put it in")
+	fmt.Printf("the keychain and add a line to %s:\n", secrets.ConfigName)
+	fmt.Printf("  fnox set -p keychain %s\n", first)
+	fmt.Printf("  %s = { provider = \"keychain\", value = \"%s\" }\n", first, first)
+}
+
+func secretsPush(args []string, env string) error {
+	target := ""
+	for _, a := range args[1:] {
+		if !strings.HasPrefix(a, "-") && a != "push" {
+			target = a
+			break
+		}
+	}
+	switch target {
+	case "github", "cloudflare":
+	default:
+		return fmt.Errorf("push where? irgo secrets push github|cloudflare")
+	}
+
+	cfg, ok, err := secrets.Load(".")
+	if err != nil || !ok {
+		return fmt.Errorf("no %s here, so there is nothing to push", secrets.ConfigName)
+	}
+	if _, _, err := secrets.Apply(".", env); err != nil {
+		return err
+	}
+
+	// Resolve everything before sending anything: a push that fails halfway
+	// leaves a destination holding some of the new values and some of the old,
+	// which is worse than not starting.
+	values := map[string]string{}
+	var missing, withheld []string
+	for _, s := range cfg.Secrets {
+		if why := withholdReason(target, s.Name); why != "" {
+			withheld = append(withheld, fmt.Sprintf("  %-28s %s", s.Name, why))
+			continue
+		}
+		v := os.Getenv(s.Name)
+		if v == "" {
+			missing = append(missing, s.Name)
+			continue
+		}
+		// A value that is set but malformed should not be copied anywhere.
+		// Pushing it propagates the typo to every destination, and each one
+		// discovers it separately, late, in its own confusing way.
+		if cv := registryForEnv(s.Name); cv != nil {
+			if err := validateConfigValue(*cv, v); err != nil {
+				return fmt.Errorf("%s: %w\n  fix it before pushing it everywhere", s.Name, err)
+			}
+		}
+		// A file-valued credential is a path here and has to arrive at the
+		// other end as contents, under the name the runner will look for.
+		if cv := registryForEnv(s.Name); cv != nil && cv.path {
+			raw, err := os.ReadFile(expandHome(v))
+			if err != nil {
+				return fmt.Errorf("%s names a file that cannot be read: %w", s.Name, err)
+			}
+			values[s.Name+base64Suffix] = base64.StdEncoding.EncodeToString(raw)
+			continue
+		}
+		values[s.Name] = v
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("these do not resolve locally, so they cannot be pushed: %s\n"+
+			"  set them first:  fnox set -p keychain <NAME>", strings.Join(missing, ", "))
+	}
+
+	if len(withheld) > 0 {
+		sort.Strings(withheld)
+		fmt.Println("Not pushed, because this destination must not hold them:")
+		for _, line := range withheld {
+			fmt.Println(line)
+		}
+		fmt.Println()
+	}
+	if len(values) == 0 {
+		return fmt.Errorf("nothing here belongs on %s", target)
+	}
+
+	names := make([]string, 0, len(values))
+	for n := range values {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	where, err := pushTargetDescription(target, env)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Push %d secret(s) to %s:\n\n", len(names), where)
+	for _, n := range names {
+		fmt.Printf("  %s\n", n)
+	}
+	fmt.Println()
+	fmt.Println("Values are read from the keychain and piped in — never printed,")
+	fmt.Println("never passed as arguments.")
+
+	if !confirm(fmt.Sprintf("Push to %s?", where), hasFlag(args, "--yes", "-y")) {
+		fmt.Println("Nothing was pushed.")
+		return nil
+	}
+
+	for _, n := range names {
+		if err := pushOne(target, n, values[n], env); err != nil {
+			return fmt.Errorf("pushing %s: %w", n, err)
+		}
+		fmt.Printf("  %s: pushed\n", n)
+	}
+	return nil
+}
+
+// pushTargetDescription names the destination, and fails early when the tool
+// for it is missing rather than after resolving secrets.
+func pushTargetDescription(target, env string) (string, error) {
+	switch target {
+	case "github":
+		if _, err := exec.LookPath("gh"); err != nil {
+			return "", fmt.Errorf("gh is not installed — https://cli.github.com")
+		}
+		out, err := exec.Command("gh", "repo", "view", "--json", "nameWithOwner",
+			"-q", ".nameWithOwner").Output()
+		if err != nil {
+			return "", fmt.Errorf("not a GitHub repository, or gh is not logged in: %w", err)
+		}
+		where := "GitHub Actions on " + strings.TrimSpace(string(out))
+		if env != "" {
+			where += ", environment " + env
+		}
+		return where, nil
+	case "cloudflare":
+		name := cloudflareWorkerName()
+		if name == "" {
+			return "", fmt.Errorf("no wrangler.toml here, so there is no Worker to push to")
+		}
+		if env != "" {
+			return "the " + name + " Worker, environment " + env, nil
+		}
+		return "the " + name + " Worker", nil
+	}
+	return "", fmt.Errorf("unknown target %q", target)
+}
+
+// pushOne sends a single secret, on stdin.
+func pushOne(target, name, value, env string) error {
+	var cmd *exec.Cmd
+	switch target {
+	case "github":
+		// A GitHub environment is a real scope with its own protection
+		// rules, which is the point: staging values should not be reachable
+		// from a job that deploys production.
+		gh := []string{"secret", "set", name}
+		if env != "" {
+			gh = append(gh, "--env", env)
+		}
+		cmd = exec.Command("gh", gh...)
+	case "cloudflare":
+		node, err := nodeBin(true)
+		if err != nil {
+			return err
+		}
+		wrangler := []string{"--yes", "wrangler@4", "secret", "put", name}
+		if env != "" {
+			wrangler = append(wrangler, "--env", env)
+		}
+		cmd = npxCommand(node, wrangler...)
+	}
+	cmd.Stdin = strings.NewReader(value)
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// currentEnv is the deployment environment this invocation is for, set once at
+// dispatch so every command resolves the same values.
+var currentEnv string
+
+// applySecrets resolves whatever the repository's fnox.toml declares, into the
+// environment, before any command reads it.
+//
+// This runs for every command, and that is the point. Store credentials are
+// resolved by `app package` through IRGO_* environment variables; secrets are
+// resolved from the keychain into those same variables. If only the deploy
+// path applied them, then declaring IRGO_APPLE_PASSWORD in fnox.toml would
+// satisfy `irgo secrets list` and be invisible to `irgo app package macos` —
+// two commands disagreeing about whether the same credential exists. It did
+// exactly that until this moved here.
+//
+// So: config says which values a build needs and where a human finds them;
+// secrets say where the machine gets the private ones. They meet in the
+// environment, and everything downstream reads one chain.
+//
+// Names already in the environment are left alone, so CI, which supplies them
+// as repository secrets, behaves exactly as before. Nothing here prints a
+// value; a secret that will not resolve is named, with the reason.
+func applySecrets() {
+	// Install what the config actually asks for, when it asks for it — the
+	// same lazily-provisioned deal as templ and Tailwind. A project whose
+	// secrets are in a keychain never sees sops mentioned.
+	if cfg, ok, err := secrets.Load("."); err == nil && ok && cfg.Uses("sops") {
+		if err := ensureGoTool("sops"); err != nil {
+			fmt.Printf("Note: %v\n", err)
+		}
+	}
+
+	applied, skipped, err := secrets.Apply(".", currentEnv)
+	if err != nil {
+		fmt.Printf("Note: %v\n", err)
+		return
+	}
+	if len(applied) > 0 {
+		fmt.Printf("Resolved from %s: %s\n", secrets.ConfigName, strings.Join(applied, ", "))
+	}
+	for name, why := range skipped {
+		fmt.Printf("Note: %s — %v\n", name, why)
+	}
+
+	// After the environment is populated, since a file-valued credential can
+	// arrive either as a path from the keychain or as contents from CI.
+	materialiseFileSecrets()
+}
+
+// withholdReason says why a secret must not go to a destination, empty when it
+// may.
+//
+// GitHub Actions builds and deploys, so it legitimately needs everything. A
+// Cloudflare Worker is only the running app: giving it the token that can
+// redeploy it, or an Apple signing key it can never use, widens what a single
+// compromised Worker is worth for no gain.
+func withholdReason(target, name string) string {
+	if target != "cloudflare" {
+		return ""
+	}
+	switch role, targets := classify(name); role {
+	case roleDeploy:
+		return "deploy credential — CI needs it, the Worker must not hold it"
+	case roleSigning:
+		return "signs " + strings.Join(targets, "/") + " builds — nothing a Worker can use"
+	}
+	return ""
+}
+
+// materialiseFileSecrets turns <ENV>_BASE64 into a real file and points <ENV>
+// at it.
+//
+// Four of the credentials irgo needs are files, not strings: the Android
+// keystore, the Windows PFX, the App Store Connect .p8 and the Play service
+// account JSON. On a laptop the setting is a path and that is the end of it.
+// CI has no filesystem to point at, so the file has to travel as its contents,
+// and something has to write it back out.
+//
+// That something used to be the workflow, in shell, for the keystore only —
+// which is why the other three had no way into CI at all. Doing it here means
+// every file-valued credential works the same way, and a workflow is only ever
+// a mapping of names.
+//
+// The decoded file is 0600 in the process's own temp dir. On a runner that
+// disappears with the runner; locally this only triggers if you set a _BASE64
+// variable yourself.
+func materialiseFileSecrets() {
+	for _, cv := range configRegistry {
+		if !cv.path || cv.env == "" || os.Getenv(cv.env) != "" {
+			continue
+		}
+		encoded := os.Getenv(cv.env + base64Suffix)
+		if encoded == "" {
+			continue
+		}
+		raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encoded))
+		if err != nil {
+			fmt.Printf("Note: %s%s is not valid base64 — %v\n", cv.env, base64Suffix, err)
+			continue
+		}
+		f, err := os.CreateTemp("", "irgo-*"+filepath.Ext(cv.display))
+		if err != nil {
+			fmt.Printf("Note: %s: %v\n", cv.env, err)
+			continue
+		}
+		if _, err := f.Write(raw); err != nil {
+			f.Close()
+			fmt.Printf("Note: %s: %v\n", cv.env, err)
+			continue
+		}
+		f.Close()
+		if err := os.Chmod(f.Name(), 0o600); err != nil {
+			fmt.Printf("Note: %s: %v\n", cv.env, err)
+			continue
+		}
+		os.Setenv(cv.env, f.Name())
+	}
+}
+
+// base64Suffix is the convention for shipping a file-valued credential through
+// an environment that can only carry strings.
+const base64Suffix = "_BASE64"
+
+// ---------------------------------------------------------------------------
+// Drift.
+//
+// Pushing is a copy, and a copy goes stale. A secret rotated in the keychain
+// but not pushed, a secret removed from fnox.toml but still sitting in the
+// repository, a repository that was never pushed to at all — none of these are
+// visible from either end, and all of them fail at the worst moment: a release
+// build, on a tag, in front of everyone.
+//
+// What can honestly be reported is names, not values. Both destinations are
+// write-only by design: GitHub will say a secret exists and when it was last
+// updated, never what it is, and neither will Cloudflare. So this reports
+// presence and age, and says plainly that agreement of names is not agreement
+// of values.
+// ---------------------------------------------------------------------------
+
+func secretsStatus(env string) error {
+	cfg, ok, err := secrets.Load(".")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		fmt.Printf("No %s here — this project declares no secrets.\n", secrets.ConfigName)
+		return nil
+	}
+	if env != "" && !cfg.HasEnv(env) {
+		return fmt.Errorf("%s declares no environment %q%s", cfg.Path, env, envHint(cfg))
+	}
+	cfg = cfg.For(env)
+
+	for _, target := range []string{"github", "cloudflare"} {
+		remote, err := remoteSecretNames(target, env)
+		if err != nil {
+			fmt.Printf("── %s ──\n  %v\n\n", target, err)
+			continue
+		}
+
+		fmt.Printf("── %s ──\n", target)
+		declared := map[string]bool{}
+		var pushed, notPushed []string
+		for _, s := range cfg.Secrets {
+			if withholdReason(target, s.Name) != "" {
+				continue // not this destination's business
+			}
+			name := s.Name
+			if cv := registryForEnv(s.Name); cv != nil && cv.path {
+				name += base64Suffix
+			}
+			declared[name] = true
+			if when, there := remote[name]; there {
+				pushed = append(pushed, fmt.Sprintf("  ok       %-30s set %s", name, when))
+			} else {
+				notPushed = append(notPushed, fmt.Sprintf("  MISSING  %-30s never pushed", name))
+			}
+		}
+
+		// A name at the destination that nothing declares any more. It cannot
+		// be read, so nobody can tell whether it still matters — which is
+		// exactly why it should be named rather than left to accumulate.
+		var orphans []string
+		for name, when := range remote {
+			if !declared[name] && looksLikeIrgoSecret(name) {
+				orphans = append(orphans, fmt.Sprintf("  ORPHAN   %-30s set %s, declared nowhere", name, when))
+			}
+		}
+
+		sort.Strings(pushed)
+		sort.Strings(notPushed)
+		sort.Strings(orphans)
+		for _, line := range append(append(notPushed, orphans...), pushed...) {
+			fmt.Println(line)
+		}
+		if len(pushed)+len(notPushed)+len(orphans) == 0 {
+			fmt.Println("  nothing to compare")
+		}
+		fmt.Println()
+	}
+
+	fmt.Println("Names only. Both destinations are write-only, so a secret being present")
+	fmt.Println("is not the same as it being current — if you have rotated one, push it.")
+	return nil
+}
+
+// looksLikeIrgoSecret keeps the orphan report to names irgo could plausibly
+// own. A repository has secrets for other things, and calling those orphans
+// would train everyone to ignore the report.
+func looksLikeIrgoSecret(name string) bool {
+	return strings.HasPrefix(name, "IRGO_") || strings.HasPrefix(name, "CLOUDFLARE_")
+}
+
+// remoteSecretNames asks a destination what it holds, and when each was set.
+func remoteSecretNames(target, env string) (map[string]string, error) {
+	switch target {
+	case "github":
+		if _, err := exec.LookPath("gh"); err != nil {
+			return nil, fmt.Errorf("gh is not installed, so this cannot be checked")
+		}
+		args := []string{"secret", "list", "--json", "name,updatedAt"}
+		if env != "" {
+			args = append(args, "--env", env)
+		}
+		out, err := exec.Command("gh", args...).Output()
+		if err != nil {
+			return nil, fmt.Errorf("not a GitHub repository, or gh is not logged in")
+		}
+		var rows []struct{ Name, UpdatedAt string }
+		if err := json.Unmarshal(out, &rows); err != nil {
+			return nil, err
+		}
+		m := map[string]string{}
+		for _, r := range rows {
+			when := r.UpdatedAt
+			if len(when) >= 10 {
+				when = when[:10]
+			}
+			m[r.Name] = when
+		}
+		return m, nil
+
+	case "cloudflare":
+		if cloudflareWorkerName() == "" {
+			return nil, fmt.Errorf("no wrangler.toml here, so there is no Worker to check")
+		}
+		node, err := nodeBin(false)
+		if err != nil {
+			return nil, fmt.Errorf("node is not available, so this cannot be checked")
+		}
+		args := []string{"--yes", "wrangler@4", "secret", "list"}
+		if env != "" {
+			args = append(args, "--env", env)
+		}
+		out, err := npxCommand(node, args...).Output()
+		if err != nil {
+			return nil, fmt.Errorf("wrangler could not list secrets — is CLOUDFLARE_API_TOKEN set?")
+		}
+		// wrangler prints a JSON array, sometimes after a banner.
+		start := strings.Index(string(out), "[")
+		if start < 0 {
+			return map[string]string{}, nil
+		}
+		var rows []struct{ Name string }
+		if err := json.Unmarshal(out[start:], &rows); err != nil {
+			return nil, err
+		}
+		m := map[string]string{}
+		for _, r := range rows {
+			m[r.Name] = "—"
+		}
+		return m, nil
+	}
+	return nil, fmt.Errorf("unknown target %q", target)
+}

--- a/cmd/irgo/cmd_server.go
+++ b/cmd/irgo/cmd_server.go
@@ -57,7 +57,7 @@ func runTest() error {
 	// with "package <mod>/templates is not in std" — which names neither templ
 	// nor the missing step. The help has always said this command regenerates;
 	// it did not, and CI trusted the documentation.
-	if err := ensureAssets(); err != nil {
+	if err := ensureAssetsAndGenerate(); err != nil {
 		return err
 	}
 	fmt.Println("Running tests...")

--- a/cmd/irgo/cmd_tools.go
+++ b/cmd/irgo/cmd_tools.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +12,23 @@ import (
 	"runtime"
 	"strings"
 )
+
+// Where irgo keeps what it installs.
+//
+// These paths were spelled out with filepath.Join(homeDir(), ".irgo", ...) in
+// seven places across four files, so nothing owned the layout and moving it
+// meant finding them all. Every caller asks here now.
+func irgoHome() string { return filepath.Join(homeDir(), ".irgo") }
+
+// irgoBinDir holds single-binary tools irgo downloads.
+func irgoBinDir() string { return filepath.Join(irgoHome(), "bin") }
+
+// goTools are the tools irgo installs with `go install`.
+//
+// This list was written out in five places — install, remove, doctor and two
+// tests — and had already drifted: install was missing gobind, so `tools
+// install` left behind a tool that `tools remove` then offered to delete.
+func goTools() []string { return []string{"templ", "air", "gomobile", "gobind"} }
 
 // runTempl generates templ files
 func runTempl() error {
@@ -34,6 +52,11 @@ const pinTempl = "v0.3.977"
 // build nobody can reproduce.
 const pinAir = "v1.63.0"
 
+// sops decrypts the secrets a deploy needs, when a project keeps them
+// encrypted in the repository rather than in a keychain. Installed when a
+// fnox.toml actually declares a sops provider, not before.
+const pinSops = "v3.12.2"
+
 func goToolPkg(name string) string {
 	switch name {
 	case "templ":
@@ -47,6 +70,8 @@ func goToolPkg(name string) string {
 		return "github.com/a-h/templ/cmd/templ@" + pinTempl
 	case "air":
 		return "github.com/air-verse/air@" + pinAir
+	case "sops":
+		return "github.com/getsops/sops/v3/cmd/sops@" + pinSops
 	case "gomobile", "gobind":
 		// Same commit as the x/mobile checkout gomobile builds against.
 		// Installing @latest while pinning the source is how a tool ends up
@@ -65,7 +90,7 @@ func goToolPkg(name string) string {
 // played safe and skipped them, leave a half-provisioned machine that silently
 // fails to re-provision.
 func irgoToolsDir() string {
-	return filepath.Join(homeDir(), ".irgo", "tools")
+	return filepath.Join(irgoHome(), "tools")
 }
 
 func markToolInstalled(name string) {
@@ -106,6 +131,17 @@ func ensureGoTool(name string) error {
 	if _, err := exec.LookPath(name); err == nil {
 		return nil
 	}
+	// mise first when it can provide the tool: it installs into a directory
+	// the developer's own version manager can see and clean up, rather than a
+	// GOBIN that irgo then has to prepend to PATH. Only some are in its
+	// registry — templ, gomobile and gobind are not — so `go install` remains
+	// the answer for the rest, and the fallback for all of them.
+	if spec, ok := miseSpec(name); ok {
+		if bin := miseTool(spec, name); bin != "" {
+			markToolInstalled(name)
+			return prependToPATH(filepath.Dir(bin))
+		}
+	}
 	pkg := goToolPkg(name)
 	if pkg == "" {
 		return fmt.Errorf("%s not found, and no install source is known for it", name)
@@ -126,6 +162,68 @@ func ensureGoTool(name string) error {
 	return nil
 }
 
+// miseSpec maps a tool to what mise is asked for, at irgo's own pin.
+//
+// Every one of these was verified to resolve — `mise ls-remote <spec>` lists
+// the exact version. An earlier version of this table claimed templ, gomobile
+// and tailwindcss were not available, on the strength of grepping
+// `mise registry`, which is capped at a thousand entries and lists none of
+// them. The backends have them all.
+//
+// The pin travels in the spec, so no mise.toml is involved and the developer's
+// own config is never consulted: `mise install templ@0.3.977` means that
+// version whatever their config says.
+func miseSpec(name string) (spec string, ok bool) {
+	v := func(pin string) string { return strings.TrimPrefix(pin, "v") }
+	switch name {
+	case "templ":
+		if p := templVersionFromGoMod(); p != "" {
+			return "go:github.com/a-h/templ/cmd/templ@" + p, true
+		}
+		return "go:github.com/a-h/templ/cmd/templ@" + v(pinTempl), true
+	// The short registry name, not the backend-qualified one. mise installs
+	// sops@3.12.2 and aqua:getsops/sops@3.12.2 into different directories, so
+	// asking for the qualified form would ignore a sops the developer already
+	// had and install a second copy beside it. tailwindcss is the exception:
+	// it is not in the registry, so only the backend spec resolves.
+	case "air":
+		return "air@" + v(pinAir), true
+	case "sops":
+		return "sops@" + v(pinSops), true
+	case "gomobile":
+		return "go:golang.org/x/mobile/cmd/gomobile@" + pinXMobile, true
+	case "gobind":
+		return "go:golang.org/x/mobile/cmd/gobind@" + pinXMobile, true
+	}
+	return "", false
+}
+
+// miseSpecFor covers every tool with a mise spec, including the two that are
+// not go-installed.
+func miseSpecFor(name string) (string, bool) {
+	switch name {
+	case "tailwindcss":
+		return "aqua:tailwindlabs/tailwindcss@" + strings.TrimPrefix(pinTailwind, "v"), true
+	case "node":
+		return "node@" + pinNode, true
+	case "jdk":
+		// doctor calls the row jdk; mise calls it java. Missing this pruned
+		// the marker for a JDK that was installed and in use, which would have
+		// left tools remove unable to give it back.
+		return "java@" + pinJDK, true
+	}
+	return miseSpec(name)
+}
+
+// prependToPATH makes a freshly installed tool resolvable for the rest of
+// this process, wherever it landed.
+func prependToPATH(dir string) error {
+	if dir == "" {
+		return nil
+	}
+	return os.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 // runCSS rebuilds the Tailwind stylesheet. static/css/output.css is generated
 // and gitignored, but it is embedded into every build — so skipping it ships an
 // unstyled app. No-op for projects without a Tailwind entry point.
@@ -143,8 +241,9 @@ func runCSS() error {
 }
 
 // ensureAssets regenerates everything that is gitignored yet embedded into a
-// build: _templ.go and the Tailwind stylesheet. Every build path runs this, so
-// a fresh clone builds correctly without the caller sequencing it by hand.
+// build: _templ.go, the Tailwind stylesheet, and whatever the project
+// generates for itself. Every build path runs this, so a fresh clone builds
+// correctly without the caller sequencing it by hand.
 func ensureAssets() error {
 	if err := runTempl(); err != nil {
 		return err
@@ -152,24 +251,102 @@ func ensureAssets() error {
 	return runCSS()
 }
 
+// ensureAssetsAndGenerate is ensureAssets plus the project's own generators.
+//
+// Kept separate because ensureAssets is the hot path: .air.toml runs
+// `irgo project assets` on every save, and generators are not save-cheap. A
+// project whose generators shell out to `go test` turns one keystroke into a
+// test compile, and a watch loop into a fork bomb — 95 of them, the first time
+// this ran. Generation belongs where correctness matters and latency does not:
+// builds, deploys and tests.
+func ensureAssetsAndGenerate() error {
+	if err := ensureAssets(); err != nil {
+		return err
+	}
+	return runGoGenerate()
+}
+
+// runGoGenerate runs the project's own generators.
+//
+// Some projects derive content from source rather than typing it — a docs site
+// generating its API reference from go/doc, say. That belongs to the project,
+// not to irgo, so this runs the standard Go mechanism and stays ignorant of
+// what any particular project generates. A project with no //go:generate
+// directives spends a few milliseconds here and produces nothing.
+//
+// It runs after templ and Tailwind, so a generator can rely on a package that
+// compiles.
+func runGoGenerate() error {
+	if !hasGoGenerate() {
+		return nil
+	}
+	fmt.Println("Running go generate...")
+	return runCommand("go", "generate", "./...")
+}
+
+// hasGoGenerate reports whether the project declares any generator, so the
+// common case prints nothing and pays nothing.
+func hasGoGenerate() bool {
+	found := false
+	_ = filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil || found {
+			return nil
+		}
+		if info.IsDir() {
+			switch info.Name() {
+			case "node_modules", "vendor", "build", "tmp", ".git":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err == nil && bytes.Contains(data, []byte("\n//go:generate")) {
+			found = true
+		}
+		return nil
+	})
+	return found
+}
+
 // installTools installs required development tools
 func installTools() error {
 	fmt.Println("Installing irgo development tools...")
 	fmt.Println()
 
-	// ensureGoTool owns pinning (templ tracks the project's go.mod version),
-	// marker-writing for uninstall, and PATH fix-up. This is just the eager
-	// form of what every build does lazily.
-	for _, tool := range []string{"templ", "air", "gomobile"} {
-		if _, err := exec.LookPath(tool); err == nil {
-			fmt.Printf("  %s: already installed\n", tool)
+	// The same table doctor reports from, so `tools install` cannot provide a
+	// different set of tools than `tools doctor` describes. Each row carries
+	// how to get itself; this is the eager form of what every build does
+	// lazily when a call needs something.
+	//
+	// Skipped here: the heavy toolchains. The Android SDK is hundreds of
+	// megabytes and only an Android build needs it, so it stays lazy — the
+	// closing message says so.
+	eager := map[string]bool{}
+	for _, name := range goTools() {
+		eager[name] = true
+	}
+	eager["tailwindcss"] = true
+
+	for _, row := range toolLocators() {
+		if !eager[row.name] {
 			continue
 		}
-		if err := ensureGoTool(tool); err != nil {
+		if row.path != "" {
+			fmt.Printf("  %s: already installed\n", row.name)
+			continue
+		}
+		if row.ensure == nil {
+			fmt.Printf("  %s: not something irgo can install\n", row.name)
+			continue
+		}
+		if err := row.ensure(); err != nil {
 			fmt.Printf("  Warning: %v\n", err)
 			continue
 		}
-		fmt.Printf("  %s: installed\n", tool)
+		fmt.Printf("  %s: installed\n", row.name)
 	}
 
 	if err := installOSPackages(); err != nil {
@@ -249,9 +426,7 @@ func uninstallTools(scope string, all, yes, keepJDK bool) error {
 	case "android":
 		planAndroid(&p, keepJDK)
 	default:
-		planGoTools(&p, all)
-		planDownloads(&p)
-		planNode(&p)
+		planTools(&p, all)
 		planHostPackages(&p, all)
 		planAndroid(&p, keepJDK)
 	}
@@ -305,5 +480,5 @@ func pruneIrgoStateDir() {
 	// os.Remove only succeeds on an empty directory, which is exactly the
 	// condition we want — never delete state that is still in use.
 	_ = os.Remove(irgoToolsDir())
-	_ = os.Remove(filepath.Join(homeDir(), ".irgo"))
+	_ = os.Remove(irgoHome())
 }

--- a/cmd/irgo/cmd_tools_doctor.go
+++ b/cmd/irgo/cmd_tools_doctor.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -443,14 +442,14 @@ func printAndroidDetail() {
 		fmt.Println("  JDK 17        not found — fetched into ~/.irgo/jdks on first build")
 	}
 
-	ndk := filepath.Join(sdk, "ndk", pinNDK)
+	ndk := ndkDir(sdk)
 	if fi, err := os.Stat(ndk); err == nil && fi.IsDir() {
 		fmt.Printf("  NDK           %s\n", pinNDK)
 	} else {
 		fmt.Printf("  NDK           %s not installed — fetched on first build\n", pinNDK)
 	}
 
-	emu := filepath.Join(sdk, "emulator", "emulator")
+	emu := emulatorBin(sdk)
 	if runtime.GOOS == "windows" {
 		emu += ".exe"
 	}

--- a/cmd/irgo/cmd_tools_remove.go
+++ b/cmd/irgo/cmd_tools_remove.go
@@ -24,7 +24,10 @@ type removalPlan struct {
 	groups []planGroup
 	// kept lists things irgo did not install, which are reported and skipped.
 	kept []string
-	acts []func(*removalTally)
+	// notes are printed after the plan: things irgo will not touch, and what
+	// to run instead.
+	notes []string
+	acts  []func(*removalTally)
 }
 
 type planGroup struct {
@@ -58,6 +61,10 @@ func confirmRemoval(p *removalPlan, yes bool) (bool, error) {
 			fmt.Printf("  %s\n", l)
 		}
 	}
+	for _, n := range p.notes {
+		fmt.Println()
+		fmt.Println(n)
+	}
 	if len(p.kept) > 0 {
 		fmt.Println()
 		fmt.Printf("Kept (irgo did not install these): %s\n", strings.Join(p.kept, ", "))
@@ -73,100 +80,184 @@ func confirmRemoval(p *removalPlan, yes bool) (bool, error) {
 			"  Nothing has been deleted. Re-run with --yes to proceed:\n" +
 			"    irgo tools remove --yes")
 	}
-	fmt.Print("Proceed? [y/N] ")
+	if !confirm("Proceed?", false) {
+		fmt.Println("Nothing removed.")
+		return false, nil
+	}
+	return true, nil
+}
+
+// confirm asks, unless told not to. Outside a terminal it refuses rather than
+// assuming yes: a script that meant to pass --yes should say so.
+func confirm(question string, yes bool) bool {
+	if yes {
+		return true
+	}
+	if !interactive() {
+		return false
+	}
+	fmt.Printf("%s [y/N] ", question)
 	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
 	if err != nil {
-		return false, nil
+		return false
 	}
 	switch strings.ToLower(strings.TrimSpace(line)) {
 	case "y", "yes":
-		return true, nil
-	}
-	fmt.Println("Nothing removed.")
-	return false, nil
-}
-
-// planGoTools adds the go-installed tools irgo owns.
-func planGoTools(p *removalPlan, all bool) {
-	for _, tool := range []string{"templ", "air", "gomobile", "gobind"} {
-		t := tool
-		if !all && !toolInstalledByIrgo(t) {
-			if pathOnPATH(t) {
-				p.kept = append(p.kept, t)
-			}
-			continue
-		}
-		path := ""
-		for _, dir := range toolBinDirs() {
-			candidate := filepath.Join(dir, exeName(t))
-			if pathExists(candidate) {
-				path = candidate
-				break
-			}
-		}
-		if path == "" {
-			continue
-		}
-		p.add("Go tools", fmt.Sprintf("%-14s %s", t, path), func(tally *removalTally) {
-			if q := removeToolPath(t); q != "" {
-				tally.report(t, "removed", q)
-			} else {
-				tally.report(t, "absent", "")
-			}
-			clearToolMarker(t)
-		})
-	}
-}
-
-func pathOnPATH(name string) bool {
-	for _, dir := range toolBinDirs() {
-		if pathExists(filepath.Join(dir, exeName(name))) {
-			return true
-		}
+		return true
 	}
 	return false
 }
 
-// planDownloads adds the pinned binaries under ~/.irgo.
-func planDownloads(p *removalPlan) {
-	bin := filepath.Join(homeDir(), ".irgo", "bin")
-	entries, err := os.ReadDir(bin)
+// planGoTools adds the go-installed tools irgo owns.
+// planMiseTools offers back the tools irgo asked mise to install.
+//
+// Only those irgo installed: the marker decides. A mise tool that was already
+// on the machine belongs to the developer and probably to other projects too,
+// and uninstalling their node because irgo happened to use it would be the
+// worst thing this command could do.
+//
+// mise uninstall rather than deleting the directory, so mise's own view stays
+// correct.
+// planTools adds every tool irgo installed, from the table doctor reports.
+//
+// This replaced four planners — Go tools, mise tools, downloads, node — that
+// each rediscovered paths doctor had already found, in their own way. One of
+// them searched a different order than the build did, which is how remove
+// could offer a copy nothing was using.
+//
+// The table knows where each tool is and how to take it back; this decides
+// what to show and groups it.
+func planTools(p *removalPlan, all bool) {
+	var mise []toolStatus
+	claimed := map[string]bool{}
+	for _, row := range toolLocators() {
+		// Tools that live in mise are reported, not removed. See planMiseNote.
+		if row.how == "mise" {
+			mise = append(mise, row)
+			continue
+		}
+		// The Android section reports these with the rest of that toolchain,
+		// where they make sense together. Listing them here too offered the
+		// same JDK twice.
+		switch row.name {
+		case "jdk", "sdkmanager", "avdmanager", "adb", "emulator", "ndk":
+			if row.path != "" {
+				claimed[irgoOwnedDir(row.path)] = true
+			}
+			continue
+		}
+		if row.remove != nil && strings.HasPrefix(row.path, irgoHome()) {
+			claimed[irgoOwnedDir(row.path)] = true
+		}
+		if row.remove == nil {
+			// Nothing of irgo's to remove. Worth naming when it is present and
+			// irgo could have installed it, so the report is not silently
+			// short.
+			if row.path != "" && row.ensure != nil && !all {
+				p.kept = append(p.kept, row.name)
+			}
+			continue
+		}
+		name, undo := row.name, row.remove
+		where := row.path
+		if row.size != "" {
+			where += "  (" + row.size + ")"
+		}
+		p.add(removalGroup(row), fmt.Sprintf("%-14s %s", name, where),
+			func(tally *removalTally) {
+				if err := undo(); err != nil {
+					tally.report(name, "failed", err.Error())
+					return
+				}
+				tally.report(name, "removed", row.path)
+			})
+	}
+	planIrgoLeftovers(p, claimed)
+	planMiseNote(p, mise)
+}
+
+// planMiseNote lists the tools irgo uses from mise, with the command to
+// remove them — rather than removing them itself.
+//
+// irgo cannot tell which of these it installed. This machine's sops 3.12.2 was
+// installed in April and its tailwindcss today, both by the same mechanism
+// into the same place, and mise records no owner. A marker file could have
+// tracked it, at the cost of a folder to keep swept.
+//
+// But ownership is the wrong question. These live where the developer's own
+// version manager can see them and other projects may be using them, so the
+// decision is theirs — and printing the command costs nothing while getting it
+// wrong costs someone else's build.
+func planMiseNote(p *removalPlan, rows []toolStatus) {
+	if len(rows) == 0 {
+		return
+	}
+	var lines []string
+	for _, r := range rows {
+		if spec, ok := miseSpecFor(r.name); ok {
+			lines = append(lines, "  mise uninstall "+spec)
+		}
+	}
+	if len(lines) == 0 {
+		return
+	}
+	p.notes = append(p.notes,
+		"From mise (shared with anything else on this machine that uses them):",
+		strings.Join(lines, "\n"),
+		"  mise prune   # anything no config asks for")
+}
+
+// planIrgoLeftovers adds anything still sitting in ~/.irgo that no tool row
+// points at any more.
+//
+// The table only names the copy a build would use. Once node came from mise,
+// the 176 MB irgo had downloaded stopped being referenced by any row and
+// would have been left on disk forever — invisible to the one command whose
+// job is finding it.
+//
+// irgo owns ~/.irgo entirely, so anything in it is irgo's to offer back.
+func planIrgoLeftovers(p *removalPlan, claimed map[string]bool) {
+	entries, err := os.ReadDir(irgoHome())
 	if err != nil {
 		return
 	}
 	for _, e := range entries {
-		if !strings.HasPrefix(e.Name(), "tailwindcss") {
+		// tools holds the markers, bin is handled per-file, jdks belongs to
+		// the Android section which reports it with the rest of that toolchain.
+		switch e.Name() {
+		case "tools", "jdks":
 			continue
 		}
-		p.add("Downloads", fmt.Sprintf("%-14s %s", "tailwindcss", filepath.Join(bin, e.Name())),
+		dir := filepath.Join(irgoHome(), e.Name())
+		if claimed[dir] || !isDir(dir) {
+			continue
+		}
+		if empty, _ := os.ReadDir(dir); len(empty) == 0 {
+			continue
+		}
+		name := e.Name()
+		p.add("Downloads", fmt.Sprintf("%-14s %s%s", name, dir, dirSizeNote(dir)),
 			func(tally *removalTally) {
-				if q := removeTailwindPath(); q != "" {
-					tally.report("tailwindcss", "removed", q)
-				} else {
-					tally.report("tailwindcss", "absent", "")
+				if err := os.RemoveAll(dir); err != nil {
+					tally.report(name, "failed", err.Error())
+					return
 				}
+				clearToolMarker(name)
+				tally.report(name, "removed", dir)
 			})
-		return
 	}
 }
 
-// planNode adds the Node irgo downloads for wrangler. It is large and it is
-// only there for Cloudflare deploys, so leaving it behind after a removal
-// would be the kind of quiet leftover this command exists to prevent.
-func planNode(p *removalPlan) {
-	dir := managedNodeHome()
-	if !isDir(dir) {
-		return
+// removalGroup is the heading a tool appears under, taken from where it came
+// from rather than from a second list.
+func removalGroup(row toolStatus) string {
+	switch row.how {
+	case "mise":
+		return "mise tools"
+	case howGoInstall:
+		return "Go tools"
 	}
-	p.add("Downloads", fmt.Sprintf("%-14s %s%s", "node", dir, dirSizeNote(dir)),
-		func(tally *removalTally) {
-			if err := os.RemoveAll(dir); err != nil {
-				tally.report("node", "failed", err.Error())
-				return
-			}
-			clearToolMarker("node")
-			tally.report("node", "removed", dir)
-		})
+	return "Downloads"
 }
 
 // planHostPackages adds packages installed through the host package manager.
@@ -218,8 +309,9 @@ func planAndroid(p *removalPlan, keepJDK bool) {
 		p.kept = append(p.kept, "android SDK (not provisioned by irgo)")
 	}
 
-	jdk := filepath.Join(home, ".irgo", "jdks")
-	if !keepJDK && pathExists(jdk) {
+	// The JDK, when irgo downloaded it. A JDK from mise belongs to mise, and
+	// `mise uninstall java@...` is how it goes.
+	if jdk := managedJDKRoot(); !keepJDK && pathExists(jdk) {
 		p.add("Android", fmt.Sprintf("%-14s %s%s", "JDK 17", jdk, dirSizeNote(jdk)), func(tally *removalTally) {
 			if os.RemoveAll(jdk) == nil {
 				tally.report("managed-jdk", "removed", jdk)

--- a/cmd/irgo/commands.go
+++ b/cmd/irgo/commands.go
@@ -153,6 +153,87 @@ templ and the Tailwind standalone binary are installed on demand. There is no
 Node, npm or package.json.`,
 	},
 
+	"secrets list": {
+		summary: "What this project needs, and whether it resolves",
+		usage: [][2]string{
+			{"", "Names and status from fnox.toml — never values"},
+			{"--env <name>", "That environment's values instead of the defaults"},
+		},
+		flags: [][2]string{{"--env <name>", "Deployment environment (or IRGO_ENV)"}},
+		notes: `Secrets live in one place, the keychain, declared per repo in fnox.toml.
+Everything else is a copy that has to be pushed and kept in step.
+
+The convention across these repos: shared credentials keep their plain name
+(CLOUDFLARE_API_TOKEN is one account, one entry, every repo points at it), and
+per-project ones carry the project as a prefix (DO_LOCATOR_KV_NAMESPACE_ID), so
+a keychain dump says which repo owns what.
+
+Set one with fnox, which prompts rather than taking it as an argument:
+  fnox set -p keychain CLOUDFLARE_API_TOKEN`,
+	},
+
+	"secrets status": {
+		summary: "Whether each destination actually has them",
+		usage: [][2]string{
+			{"", "Compare what is declared against GitHub and the Worker"},
+			{"--env <name>", "That environment's destinations"},
+		},
+		flags: [][2]string{{"--env <name>", "Deployment environment (or IRGO_ENV)"}},
+		notes: `Pushing is a copy, and a copy goes stale. A secret rotated in the keychain
+but never pushed, or removed from fnox.toml but still sitting in the
+repository, is invisible from both ends until a release build fails on a tag.
+
+Names only. Both destinations are write-only by design — GitHub will say a
+secret exists and when it was last updated, never what it is — so agreement of
+names is not agreement of values.
+
+ORPHAN means the destination holds an IRGO_/CLOUDFLARE_ secret that nothing
+declares any more. It cannot be read back, so nobody can tell whether it still
+matters; that is the reason to name it rather than let it accumulate.`,
+	},
+
+	"secrets push": {
+		summary: "Copy them where they are also needed",
+		usage: [][2]string{
+			{"github", "GitHub Actions secrets for this repository"},
+			{"cloudflare", "Runtime secrets for this Worker"},
+		},
+		flags: [][2]string{
+			{"--yes, -y", "Do not ask"},
+			{"--env <name>", "Push that environment's values (or IRGO_ENV)"},
+		},
+		notes: `CI cannot read a laptop's keychain and neither can a Worker at runtime, so
+both need their own copy. This is what keeps them in step.
+
+Everything is resolved before anything is sent: a push that fails halfway
+would leave a destination holding some new values and some old.
+
+Only what a destination should hold is sent. A Worker gets the app's own
+secrets; the token that can redeploy it, and signing keys it could never use,
+stay in CI.
+
+Environments are the same names with different values, declared as
+[env.staging.secrets] in fnox.toml. They map onto what each destination
+already has — a GitHub environment, a wrangler --env — so staging values are
+not reachable from a job that deploys production.
+
+Values are piped in on stdin, so a secret never reaches the shell history, the
+process list, or this program's output. Both gh and wrangler read them that
+way.`,
+	},
+
+	"project generate": {
+		summary: "Run the project's own generators",
+		usage:   [][2]string{{"", "Run every //go:generate directive in the project"}},
+		notes: `For projects that derive content from source rather than typing it — a docs
+site generating its API reference, say. Most projects have no generators and
+this does nothing.
+
+Builds, deploys and tests run it for you. It is deliberately NOT part of
+` + "`project assets`" + `: that runs on every save under hot reload, and a
+generator is rarely save-cheap.`,
+	},
+
 	"project test": {
 		summary: "Run the tests",
 		usage:   [][2]string{{"", "Regenerate assets, then go test ./..."}},
@@ -368,8 +449,15 @@ download can be done deliberately rather than in the middle of a build.`,
 		notes: `Shows what it will delete, with sizes, and asks first. Outside a terminal it
 refuses rather than assuming yes.
 
-Only what irgo installed is removed: each install leaves a marker, and anything
-without one is left alone, so a toolchain you set up yourself survives.`,
+Only what irgo installed is removed, so a toolchain you set up yourself
+survives. Anything under ~/.irgo is irgo's by virtue of being there.
+
+Tools that came from mise are left alone, even ones irgo asked for. They live
+where your own version manager can see them, other projects may be using them,
+and mise already removes them:
+
+  mise uninstall sops@3.12.2
+  mise prune`,
 	},
 
 	// ---- server ------------------------------------------------------------

--- a/cmd/irgo/help.go
+++ b/cmd/irgo/help.go
@@ -29,6 +29,9 @@ APP       what gets built, run, shipped and installed
 TOOLS     the toolchains on this machine
 ` + renderNounSection("tools") + `
 
+SECRETS   the credentials this project needs, and where they go
+` + renderNounSection("secrets") + `
+
 SERVER    the development server
 ` + renderNounSection("server") + `
 
@@ -65,7 +68,7 @@ func printCommandHelp(noun, verb string) {
 	}
 
 	switch key {
-	case "project", "app", "tools", "server":
+	case "project", "app", "tools", "secrets", "server":
 		fmt.Printf("irgo %s - %s\n\n", noun, nounSummary[noun])
 		fmt.Println("Verbs:")
 		fmt.Println(renderNounVerbs(noun, "irgo "))
@@ -131,6 +134,7 @@ var nounSummary = map[string]string{
 	"project": "the repository you are in",
 	"app":     "what gets built, run, shipped and installed",
 	"tools":   "the toolchains on this machine",
+	"secrets": "the credentials this project needs, and where they go",
 	"server":  "the development server",
 }
 
@@ -139,7 +143,7 @@ var nounSummary = map[string]string{
 func renderCommandTable() string {
 	var b strings.Builder
 	b.WriteString("| Command | What it does |\n|---|---|\n")
-	for _, noun := range []string{"project", "app", "tools", "server"} {
+	for _, noun := range []string{"project", "app", "tools", "secrets", "server"} {
 		for _, verb := range nounVerbs[noun] {
 			key := noun + " " + verb
 			c := commands[key]
@@ -210,7 +214,7 @@ func printCommandsJSON() {
 	}
 
 	var out []commandDoc
-	for _, noun := range []string{"project", "app", "tools", "server"} {
+	for _, noun := range []string{"project", "app", "tools", "secrets", "server"} {
 		for _, verb := range nounVerbs[noun] {
 			c := commands[noun+" "+verb]
 			d := commandDoc{

--- a/cmd/irgo/help_test.go
+++ b/cmd/irgo/help_test.go
@@ -149,6 +149,7 @@ func TestEveryFlagIsDocumented(t *testing.T) {
 		"--exists": true, // pkg-config
 		"--yes":    true, // npx
 		"--help":   true, // handled before dispatch
+		"--json":   true, // gh repo view
 	}
 
 	help := captureStdout(t, printUsage)
@@ -253,7 +254,7 @@ func TestDeployBuildsThroughTheBuildPath(t *testing.T) {
 // — cloned from the default branch with no ref. A build that changes without a
 // commit is a build nobody can reproduce.
 func TestEveryInstalledToolIsPinned(t *testing.T) {
-	for _, tool := range []string{"templ", "air", "gomobile", "gobind"} {
+	for _, tool := range goTools() {
 		pkg := goToolPkg(tool)
 		if pkg == "" {
 			t.Errorf("%s has no install source", tool)
@@ -275,7 +276,7 @@ func TestEveryInstalledToolIsPinned(t *testing.T) {
 // and reported air as drifted because its usage text contains a Go version.
 func TestInstallRecordsThePinnedVersion(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	for _, tool := range []string{"templ", "air", "gomobile", "gobind"} {
+	for _, tool := range goTools() {
 		markToolInstalled(tool)
 		got := installedVersion(tool)
 		if got == "" {
@@ -301,7 +302,10 @@ func TestTestRegeneratesAssets(t *testing.T) {
 	if i < 0 {
 		t.Fatal("runTest not found")
 	}
-	if !strings.Contains(body[i:], "ensureAssets()") {
+	// Either form regenerates; the Generate variant also runs the project's
+	// own generators, which is what a test run wants.
+	if !strings.Contains(body[i:], "ensureAssets()") &&
+		!strings.Contains(body[i:], "ensureAssetsAndGenerate()") {
 		t.Error("project test does not regenerate assets, but its help says it does — " +
 			"a fresh clone cannot compile the templates package")
 	}

--- a/cmd/irgo/templates/fnox.toml
+++ b/cmd/irgo/templates/fnox.toml
@@ -1,0 +1,61 @@
+# Which secrets this project needs, and where to find them.
+#
+# No values live here. This file names them; the values live in the OS keychain,
+# so this is safe to commit and a checkout has nothing to leak.
+#
+#   irgo secrets list             what this project needs, and what is missing
+#   irgo secrets status           whether GitHub and the Worker actually have it
+#   irgo secrets push github      copy them into GitHub Actions
+#   irgo secrets push cloudflare  copy them into the Worker's runtime
+#
+# Set one with fnox, which prompts rather than taking the value as an argument
+# — an argument ends up in shell history and in `ps`:
+#
+#   fnox set -p keychain CLOUDFLARE_API_TOKEN
+#
+# fnox is optional. The same entries can be written with the platform's own
+# tool, and irgo reads the keychain directly either way:
+#
+#   security add-generic-password -U -s fnox -a CLOUDFLARE_API_TOKEN -w
+#
+# Naming, so one keychain can serve every project:
+#
+#   Shared      plain name. CLOUDFLARE_API_TOKEN is one account and one entry;
+#               every project that deploys there points at the same name, and
+#               rotating it once is enough.
+#   Per-project prefixed with the project. MYAPP_DATABASE_URL. The prefix is
+#               the namespace, so a keychain dump says which project owns what.
+#
+# In CI there is no keychain, so the same names come from the runner's own
+# secret store. An environment variable always wins over this file, which is
+# why CI needs no special case.
+
+[providers.keychain]
+type = "keychain"
+service = "fnox"
+
+[secrets]
+# Uncomment what this project actually uses. `irgo secrets list` names the
+# signing credentials irgo knows about, if you ship to a store.
+
+# Deploying to Cloudflare Workers:
+# CLOUDFLARE_API_TOKEN  = { provider = "keychain", value = "CLOUDFLARE_API_TOKEN" }
+# CLOUDFLARE_ACCOUNT_ID = { provider = "keychain", value = "CLOUDFLARE_ACCOUNT_ID" }
+
+# Environments — the same names against different backing services.
+#
+# Declare only what differs. A name declared above keeps working in every
+# environment, so adding staging does not mean restating the whole file, and
+# the two cannot drift apart.
+#
+#   irgo secrets list --env staging
+#   irgo secrets push cloudflare --env staging
+#
+# The environment maps onto what each destination already has: a GitHub
+# environment, which has its own protection rules, and wrangler's --env. So
+# staging values are not reachable from a job that deploys production.
+#
+# In CI set IRGO_ENV once for the job and every irgo command follows it.
+#
+# [env.staging.secrets]
+# DATABASE_URL = { provider = "keychain", value = "MYAPP_STAGING_DATABASE_URL" }

--- a/cmd/irgo/templates/github/workflows/release.yml
+++ b/cmd/irgo/templates/github/workflows/release.yml
@@ -1,12 +1,22 @@
 # Store packages for every target, built on the OS each one requires and
 # attached to a GitHub Release.
 #
-# Scaffolded by `irgo project ci`. Each job is skipped unless its signing secrets are
-# configured, so this is useful before you have any of them: what is set gets
-# packaged, what is not is skipped rather than failing the run.
+# Scaffolded by `irgo project ci`. Each job is skipped unless its signing
+# secrets are configured, so this is useful before you have any of them: what
+# is set gets packaged, what is not is skipped rather than failing the run.
 #
-# Configure the values with `irgo app package setup <store>`, then add them as
-# repository secrets. `irgo app package setup --check` reports what is missing.
+# The secret names here are the environment variables irgo already resolves,
+# which is why no job passes a --flag. Get them from a laptop to here with:
+#
+#   irgo secrets list             what this project needs
+#   irgo secrets push github      copy it into this repository
+#
+# They used to be spelled differently on each side — IOS_TEAM_ID here against
+# IRGO_IOS_TEAM in the CLI — so pushing them configured nothing. A test now
+# checks every name on this page against the CLI's own registry.
+#
+# Credentials that are files (keystore, PFX, .p8, Play JSON) travel as
+# <NAME>_BASE64 and irgo writes them back out before the build looks for them.
 
 name: release
 
@@ -23,24 +33,20 @@ jobs:
     # env. Mapping them here lets each job skip cleanly when unconfigured
     # instead of failing, so this workflow is usable before you have any.
     env:
-      KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-      KEYSTORE_PASS: ${{ secrets.ANDROID_KEYSTORE_PASS }}
-      KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-      KEY_PASS: ${{ secrets.ANDROID_KEY_PASS }}
+      IRGO_ANDROID_KEYSTORE_BASE64: ${{ secrets.IRGO_ANDROID_KEYSTORE_BASE64 }}
+      IRGO_ANDROID_KEYSTORE_PASS: ${{ secrets.IRGO_ANDROID_KEYSTORE_PASS }}
+      IRGO_ANDROID_KEY_ALIAS: ${{ secrets.IRGO_ANDROID_KEY_ALIAS }}
+      IRGO_ANDROID_KEY_PASS: ${{ secrets.IRGO_ANDROID_KEY_PASS }}
     steps:
       - uses: {{CHECKOUT}}
       - uses: {{SETUP_GO}}
         with:
           go-version-file: go.mod
       - name: Package
-        if: env.KEYSTORE_B64 != ''
-        run: |
-          echo "$KEYSTORE_B64" | base64 -d > release.keystore
-          irgo app package android --keystore release.keystore \
-            --keystore-pass "$KEYSTORE_PASS" --key-alias "$KEY_ALIAS" --key-pass "$KEY_PASS"
-          rm -f release.keystore
+        if: env.IRGO_ANDROID_KEYSTORE_BASE64 != ''
+        run: go tool irgo app package android
       - uses: {{UPLOAD_ARTIFACT}}
-        if: env.KEYSTORE_B64 != ''
+        if: env.IRGO_ANDROID_KEYSTORE_BASE64 != ''
         with:
           name: android-aab
           path: dist/
@@ -50,7 +56,7 @@ jobs:
     name: iOS (.ipa)
     runs-on: macos-latest
     env:
-      IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
+      IRGO_IOS_TEAM: ${{ secrets.IRGO_IOS_TEAM }}
     steps:
       - uses: {{CHECKOUT}}
       - uses: {{SETUP_GO}}
@@ -59,10 +65,10 @@ jobs:
       # Signing needs a Distribution cert and provisioning profile in the
       # runner keychain — e.g. apple-actions/import-codesign-certs.
       - name: Package
-        if: env.IOS_TEAM_ID != ''
-        run: go tool irgo app package ios --team "$IOS_TEAM_ID"
+        if: env.IRGO_IOS_TEAM != ''
+        run: go tool irgo app package ios
       - uses: {{UPLOAD_ARTIFACT}}
-        if: env.IOS_TEAM_ID != ''
+        if: env.IRGO_IOS_TEAM != ''
         with:
           name: ios-ipa
           path: dist/
@@ -72,17 +78,23 @@ jobs:
     name: macOS (.app/.dmg)
     runs-on: macos-latest
     env:
-      MACOS_IDENTITY: ${{ secrets.MACOS_IDENTITY }}
+      IRGO_MACOS_IDENTITY: ${{ secrets.IRGO_MACOS_IDENTITY }}
+      # Notarization, if you have it. Without these the .app is signed but
+      # not notarized, which is fine for a direct download you tell people
+      # to right-click-open.
+      IRGO_APPLE_ID: ${{ secrets.IRGO_APPLE_ID }}
+      IRGO_APPLE_PASSWORD: ${{ secrets.IRGO_APPLE_PASSWORD }}
+      IRGO_MACOS_TEAM: ${{ secrets.IRGO_MACOS_TEAM }}
     steps:
       - uses: {{CHECKOUT}}
       - uses: {{SETUP_GO}}
         with:
           go-version-file: go.mod
       - name: Package
-        if: env.MACOS_IDENTITY != ''
-        run: go tool irgo app package macos --identity "$MACOS_IDENTITY" --dmg
+        if: env.IRGO_MACOS_IDENTITY != ''
+        run: go tool irgo app package macos --dmg
       - uses: {{UPLOAD_ARTIFACT}}
-        if: env.MACOS_IDENTITY != ''
+        if: env.IRGO_MACOS_IDENTITY != ''
         with:
           name: macos-dmg
           path: dist/
@@ -92,7 +104,11 @@ jobs:
     name: Windows (.msix)
     runs-on: windows-latest
     env:
-      WINDOWS_PUBLISHER: ${{ secrets.WINDOWS_PUBLISHER }}
+      IRGO_WINDOWS_PUBLISHER: ${{ secrets.IRGO_WINDOWS_PUBLISHER }}
+      # A real cert, if you have one. Without it the package is test-signed,
+      # which the Store re-signs on upload anyway.
+      IRGO_WINDOWS_CERT_BASE64: ${{ secrets.IRGO_WINDOWS_CERT_BASE64 }}
+      IRGO_WINDOWS_CERT_PASS: ${{ secrets.IRGO_WINDOWS_CERT_PASS }}
     steps:
       - uses: {{CHECKOUT}}
       - uses: {{SETUP_GO}}
@@ -100,10 +116,10 @@ jobs:
           go-version-file: go.mod
       # MakeAppx/signtool come from the Windows SDK, preinstalled on the runner.
       - name: Package
-        if: env.WINDOWS_PUBLISHER != ''
-        run: go tool irgo app package windows --publisher "$env:WINDOWS_PUBLISHER"
+        if: env.IRGO_WINDOWS_PUBLISHER != ''
+        run: go tool irgo app package windows
       - uses: {{UPLOAD_ARTIFACT}}
-        if: env.WINDOWS_PUBLISHER != ''
+        if: env.IRGO_WINDOWS_PUBLISHER != ''
         with:
           name: windows-msix
           path: dist/

--- a/cmd/irgo/tools_android_sdk.go
+++ b/cmd/irgo/tools_android_sdk.go
@@ -90,7 +90,35 @@ func isJava17(bin string) bool {
 // is fully self-contained and cross-platform — no brew/apt/winget anywhere.
 const managedJDKRel = ".irgo/jdks/temurin-17"
 
+// pinJDK is the exact Temurin build the Android toolchain uses.
+//
+// irgo's own downloader asks Adoptium for latest/17/ga, so two developers who
+// ran it months apart get different JDKs and neither can say which. mise can
+// name the build, so when it is doing the installing the version is pinned
+// like every other tool. The Adoptium fallback keeps its old behaviour, since
+// there is nothing to pin it to.
+const pinJDK = "temurin-17.0.20+8"
+
 func managedJDKHome() string { return filepath.Join(homeDir(), managedJDKRel) }
+
+// managedJDKRoot is the directory holding every JDK irgo has downloaded — the
+// parent of managedJDKHome. `tools remove` used to spell this out as
+// filepath.Join(home, ".irgo", "jdks"), which meant a change to managedJDKRel
+// would leave it deleting the wrong directory.
+func managedJDKRoot() string { return filepath.Dir(managedJDKHome()) }
+
+// ndkDir is the pinned NDK inside an SDK. Built in four places before this,
+// once of them in doctor, so doctor could look somewhere the build does not.
+func ndkDir(sdk string) string { return filepath.Join(sdk, "ndk", pinNDK) }
+
+// emulatorBin is the emulator inside an SDK. Also built in four places.
+func emulatorBin(sdk string) string {
+	name := "emulator"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(sdk, "emulator", name)
+}
 
 // findManagedJDK returns the extracted JDK home under ~/.irgo/jdks/temurin-17
 // (the Adoptium archive contains a single jdk-17.x.y/ dir — on macOS with a
@@ -117,6 +145,37 @@ func findManagedJDK() string {
 
 // installManagedJDK downloads a Temurin JDK 17 (Adoptium) for the current
 // platform/arch and extracts it into ~/.irgo/jdks/temurin-17. Returns its home.
+// miseJDK returns a JDK from mise, at irgo's pin.
+//
+// Returns "" when mise cannot supply it, which sends the caller to the
+// Adoptium download that has always been there.
+func miseJDK(install bool) string {
+	find := miseWhere
+	if install {
+		if bin := miseTool("java@"+pinJDK, "java"); bin != "" {
+			return javaHomeFor(bin)
+		}
+		return ""
+	}
+	mise, ok := miseCmd()
+	if !ok {
+		return ""
+	}
+	if bin := find(mise, "java@"+pinJDK, "java"); bin != "" {
+		return javaHomeFor(bin)
+	}
+	return ""
+}
+
+// javaHomeFor turns .../bin/java into the JAVA_HOME the Android tools want.
+func javaHomeFor(bin string) string {
+	home := filepath.Dir(filepath.Dir(bin))
+	if !isJava17(bin) {
+		return ""
+	}
+	return home
+}
+
 func installManagedJDK() (string, error) {
 	// Idempotent: reuse an already-extracted JDK 17.
 	if p := findManagedJDK(); p != "" && isJava17(filepath.Join(p, "bin", "java")) {
@@ -181,6 +240,12 @@ func installManagedJDK() (string, error) {
 // copy, macOS java_home, Linux /usr/lib/jvm, java on PATH. With install=true,
 // a missing JDK is downloaded cross-platform into ~/.irgo/jdks.
 func detectJDK17(install bool) (string, bool) {
+	// mise, at the pinned build, before irgo's own 308 MB download. Looked up
+	// whether or not this call may install, so doctor names the JDK a build
+	// would use rather than a second copy.
+	if home := miseJDK(false); home != "" {
+		return home, true
+	}
 	if jh := os.Getenv("JAVA_HOME"); jh != "" {
 		if isJava17(filepath.Join(jh, "bin", "java")) {
 			return jh, true
@@ -211,6 +276,11 @@ func detectJDK17(install bool) (string, bool) {
 		return "", true
 	}
 	if install {
+		// mise at the pinned build first: 308 MB that a machine with mise does
+		// not need a second copy of, and a version irgo can actually name.
+		if home := miseJDK(true); home != "" {
+			return home, true
+		}
 		p, err := installManagedJDK()
 		if err != nil {
 			fmt.Printf("  ! automatic JDK install failed: %v\n", err)
@@ -564,7 +634,7 @@ func ensureEmulatorRunning() error {
 	if adbRunning() {
 		return nil
 	}
-	emu := filepath.Join(androidHome(), "emulator", "emulator")
+	emu := emulatorBin(androidHome())
 	if runtime.GOOS == "windows" {
 		emu += ".exe"
 	}
@@ -759,7 +829,7 @@ func ensureAndroidToolchain(withEmulator bool, avdName string) error {
 
 	// Fast path: when the pinned NDK + platform-tools already exist the
 	// components are installed — skip the sdkmanager round-trip entirely.
-	ndk := filepath.Join(sdk, "ndk", pinNDK)
+	ndk := ndkDir(sdk)
 	if !isDir(ndk) || !isDir(filepath.Join(sdk, "platform-tools")) {
 		fmt.Println("Accepting Android SDK licenses...")
 		acceptLicenses(sdkm, sdk)
@@ -803,7 +873,7 @@ func installAndroidTools(withEmulator bool, avdName string) error {
 		return err
 	}
 	sdk := androidHome()
-	ndk := filepath.Join(sdk, "ndk", pinNDK)
+	ndk := ndkDir(sdk)
 	fmt.Printf("\nAndroid toolchain ready.\n")
 	fmt.Printf("  ANDROID_HOME=%s\n", sdk)
 	fmt.Printf("  ANDROID_NDK_HOME=%s\n", ndk)
@@ -892,7 +962,7 @@ func findAvdDir(avdName string) string {
 		}
 	}
 	// Ask the emulator where it thinks the AVD lives.
-	emu := filepath.Join(androidHome(), "emulator", "emulator")
+	emu := emulatorBin(androidHome())
 	if runtime.GOOS == "windows" {
 		emu += ".exe"
 	}
@@ -954,7 +1024,7 @@ func uninstallAndroidTools(removeJDK bool) error {
 	}
 	if removeJDK {
 		fmt.Println("Removing managed JDK (~/.irgo/jdks)...")
-		_ = os.RemoveAll(filepath.Join(home, ".irgo", "jdks"))
+		_ = os.RemoveAll(managedJDKRoot())
 		_ = os.Remove(filepath.Join(home, ".irgo")) // empty parent
 	}
 
@@ -983,8 +1053,8 @@ func uninstallAndroidTools(removeJDK bool) error {
 func doctorAndroid() error {
 	fail := false
 	sdk := androidHome()
-	ndk := filepath.Join(sdk, "ndk", pinNDK)
-	emulator := filepath.Join(sdk, "emulator", "emulator")
+	ndk := ndkDir(sdk)
+	emulator := emulatorBin(sdk)
 
 	fmt.Println("Android toolchain doctor:")
 	fmt.Printf("  ANDROID_HOME: %s\n", sdk)

--- a/cmd/irgo/tools_doctor_locators_test.go
+++ b/cmd/irgo/tools_doctor_locators_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -58,8 +59,15 @@ func toolsIrgoRuns() []string {
 		"templ": true, "air": true, "gomobile": true, "gobind": true,
 		"node": true, "java": true, "keytool": true, "adb": true,
 		"sdkmanager": true, "avdmanager": true, "go": true, "git": true,
-		"sops": true, "xcrun": true, "xcodebuild": true, "codesign": true,
-		"security": true, "clang": true,
+		"sops": true,
+	}
+	// Apple's tools are only expected where they can exist. doctor lists them
+	// on darwin and not elsewhere, correctly — so requiring them everywhere
+	// failed this on Linux while describing a real absence as a defect.
+	if runtime.GOOS == "darwin" {
+		for _, n := range []string{"xcrun", "xcodebuild", "codesign", "security", "clang"} {
+			want[n] = true
+		}
 	}
 	var names []string
 	for _, n := range strings.Split(strings.TrimSpace(string(out)), "\n") {

--- a/cmd/irgo/tools_doctor_locators_test.go
+++ b/cmd/irgo/tools_doctor_locators_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestEveryToolIrgoRunsIsLocated — doctor is how a developer finds out where
+// everything on their machine is. A tool the CLI runs but doctor never names
+// is one nobody can locate when a build picks up the wrong copy.
+func TestEveryToolIrgoRunsIsLocated(t *testing.T) {
+	located := map[string]bool{}
+	for _, r := range toolLocators() {
+		located[r.name] = true
+	}
+
+	// Named differently by doctor than by the binary, on purpose: "jdk" is
+	// clearer than "java" next to the Android rows, and tailwindcss is
+	// installed under a versioned filename.
+	alias := map[string]string{"java": "jdk", "keytool": "jdk"}
+
+	for _, name := range toolsIrgoRuns() {
+		if a, ok := alias[name]; ok {
+			name = a
+		}
+		if !located[name] {
+			t.Errorf("irgo runs %s but doctor never says where it is", name)
+		}
+	}
+}
+
+// TestLocatedToolsResolveOrReportAbsent — a row must either carry a real path
+// or admit it has none. A path that does not exist is worse than a blank,
+// because it sends someone to look at a file that is not there.
+func TestLocatedToolsResolveOrReportAbsent(t *testing.T) {
+	for _, r := range toolLocators() {
+		if r.path == "" {
+			continue
+		}
+		if !strings.HasPrefix(r.path, "/") && !strings.Contains(r.path, ":\\") {
+			t.Errorf("%s has a relative path %q — doctor should report where it actually is", r.name, r.path)
+		}
+	}
+}
+
+// toolsIrgoRuns reads the binaries this package actually invokes, so the check
+// above compares doctor against the code rather than against another list.
+func toolsIrgoRuns() []string {
+	out, err := exec.Command("sh", "-c",
+		`grep -rhoE '(exec\.Command|LookPath)\("[a-zA-Z0-9_.-]+"' *.go | sed -E 's/.*\("//;s/"//' | sort -u`).Output()
+	if err != nil {
+		return nil
+	}
+	// Only the ones irgo is responsible for having. Host utilities like sudo,
+	// open or apt-get are not toolchain, and naming them would be noise.
+	want := map[string]bool{
+		"templ": true, "air": true, "gomobile": true, "gobind": true,
+		"node": true, "java": true, "keytool": true, "adb": true,
+		"sdkmanager": true, "avdmanager": true, "go": true, "git": true,
+		"sops": true, "xcrun": true, "xcodebuild": true, "codesign": true,
+		"security": true, "clang": true,
+	}
+	var names []string
+	for _, n := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if want[n] {
+			names = append(names, n)
+		}
+	}
+	return names
+}

--- a/cmd/irgo/tools_doctor_versions.go
+++ b/cmd/irgo/tools_doctor_versions.go
@@ -15,8 +15,76 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
+
+// Where a tool comes from. Constants because these were nine string literals
+// across two functions, and a wording change meant finding them all.
+const (
+	howGoInstall = "go install"
+	howDownload  = "downloaded by irgo"
+	howAndroid   = "Android SDK, by irgo"
+	howMise      = "mise, else downloaded by irgo"
+	howPlatform  = "provided by the platform"
+	howHostPkg   = "host package manager"
+	howOptional  = "optional — irgo uses it if present"
+	howPrereq    = "prerequisite — compiles irgo"
+)
+
+// sourceOf says where the copy on this machine actually came from.
+//
+// Two questions kept getting conflated. How irgo *would* install a tool is a
+// fact about irgo — miseSpec and goToolPkg answer it. How the copy that is
+// here *did* arrive is a fact about the machine, and irgo does not always know:
+// templ may be irgo's `go install` or the developer's.
+//
+// This answers the second, and asks the authority rather than reading the path.
+// mise is asked whether it owns the binary; a substring check called templ a
+// mise package because it sits in the bin directory of a Go that mise manages,
+// and `tools remove` then printed a `mise uninstall templ` that matched
+// nothing.
+func sourceOf(name, path string) string {
+	if path == "" {
+		return ""
+	}
+	// mise, asked directly: is this path inside an install it owns?
+	//
+	// Containment rather than equality: a row may hold the binary (node) or
+	// the directory (the JDK, which is a JAVA_HOME), and both live under the
+	// same install.
+	if spec, ok := miseSpecFor(name); ok {
+		if dir := miseInstallDir(spec); dir != "" && strings.HasPrefix(path, dir) {
+			return "mise"
+		}
+	}
+	switch {
+	case strings.HasPrefix(path, androidHome()):
+		return howAndroid
+	case strings.HasPrefix(path, irgoHome()):
+		return howDownload
+	case gobinDir() != "" && strings.HasPrefix(path, gobinDir()):
+		return howGoInstall
+	case goToolPkg(name) != "":
+		// irgo installs this with `go install`, and it is not a mise package,
+		// so wherever it landed that is how it got there.
+		return howGoInstall
+	}
+	return "yours"
+}
+
+// miseInstallDir is where mise put a spec, or "" if it does not have it.
+func miseInstallDir(spec string) string {
+	mise, ok := miseCmd()
+	if !ok {
+		return ""
+	}
+	out, err := exec.Command(mise, "where", spec).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
 
 // toolStatus is one row.
 type toolStatus struct {
@@ -24,7 +92,62 @@ type toolStatus struct {
 	path    string // where it is, "" when absent
 	have    string // version reported by the tool
 	want    string // version irgo pins
-	managed bool   // irgo installed it
+	managed bool   // irgo installed it, per the marker in ~/.irgo/tools
+	// ensure gets the tool when it is missing. nil means irgo cannot provide
+	// it — Xcode, a C compiler — and doctor says so rather than pretending.
+	ensure func() error
+	// how it is obtained, in a few words. Printed, because otherwise the only
+	// way to learn whether a tool comes from `go install`, a download or mise
+	// is to read the source — and reading the source is what doctor is for.
+	how string
+	// size on disk, for directories irgo owns. "" for everything else.
+	size string
+	// remove undoes the install, when irgo was the one that did it. nil means
+	// there is nothing of irgo's to take back.
+	remove func() error
+}
+
+// irgoDiskUse reports how much space a tool irgo installed is using.
+//
+// Only under irgoHome: measuring the platform's own directories would be slow
+// and none of irgo's business. Returns "" when there is nothing to say.
+func irgoDiskUse(path string) string {
+	if path == "" || !strings.HasPrefix(path, irgoHome()) {
+		return ""
+	}
+	// The tool's own directory, not the binary — except in ~/.irgo/bin, which
+	// holds one file per tool, so walking up there would report the whole
+	// directory as the size of each one. tailwindcss read 76 MB that way.
+	dir := path
+	if filepath.Dir(path) == irgoBinDir() {
+		if fi, err := os.Stat(path); err == nil {
+			return humanBytes(fi.Size())
+		}
+		return ""
+	}
+	for filepath.Dir(dir) != irgoHome() && filepath.Dir(dir) != "/" && dir != "" {
+		dir = filepath.Dir(dir)
+	}
+	var total int64
+	_ = filepath.Walk(dir, func(_ string, fi os.FileInfo, err error) error {
+		if err == nil && !fi.IsDir() {
+			total += fi.Size()
+		}
+		return nil
+	})
+	return humanBytes(total)
+}
+
+func humanBytes(n int64) string {
+	switch {
+	case n == 0:
+		return ""
+	case n > 1<<30:
+		return fmt.Sprintf("%.1f GB", float64(n)/(1<<30))
+	case n > 1<<20:
+		return fmt.Sprintf("%d MB", n/(1<<20))
+	}
+	return fmt.Sprintf("%d KB", n/(1<<10))
 }
 
 // installedVersion is the version irgo recorded when it installed the tool.
@@ -67,8 +190,13 @@ func wantedVersion(tool string) string {
 // goToolStatuses reports every Go tool irgo installs.
 func goToolStatuses() []toolStatus {
 	var out []toolStatus
-	for _, name := range []string{"templ", "air", "gomobile", "gobind"} {
-		st := toolStatus{name: name, want: wantedVersion(name), managed: toolInstalledByIrgo(name)}
+	for _, name := range goTools() {
+		tool := name
+		st := toolStatus{
+			name: name, want: wantedVersion(name), managed: toolInstalledByIrgo(name),
+			ensure: func() error { return ensureGoTool(tool) },
+			how:    howGoInstall,
+		}
 		if p, err := exec.LookPath(name); err == nil {
 			st.path = p
 			st.have = installedVersion(name)
@@ -78,32 +206,388 @@ func goToolStatuses() []toolStatus {
 	return out
 }
 
-// nodeStatus reports the Node irgo downloads for wrangler. It is 176 MB and
-// nothing mentioned it until `tools remove` listed it, which is a poor way to
-// discover a large download.
+// nodeStatus reports the Node used for wrangler. It is 176 MB when irgo has to
+// download one, and nothing mentioned it until `tools remove` listed it, which
+// is a poor way to discover a large download.
+//
+// Asks nodeBin rather than working the path out again. The copy that used to
+// live here searched in the opposite order — managed before PATH — and did not
+// know about node.exe, so doctor could name a Node that no build would use.
+// A tool's own file decides where it is; doctor reports what it says.
 func nodeStatus() toolStatus {
-	st := toolStatus{name: "node", want: pinNode, managed: toolInstalledByIrgo("node")}
-	bin := filepath.Join(managedNodeHome(), "bin", "node")
-	if !pathExists(bin) {
-		if p, err := exec.LookPath("node"); err == nil {
-			bin = p
-		} else {
+	st := toolStatus{
+		name: "node", want: pinNode, managed: toolInstalledByIrgo("node"),
+		ensure: func() error { _, err := nodeBin(true); return err },
+		how:    howMise,
+	}
+	bin, err := nodeBin(false)
+	if err != nil {
+		return st
+	}
+	st.path = bin
+	// node --version is reliable, unlike the Go tools'.
+	if out, err := exec.Command(bin, "--version").Output(); err == nil {
+		st.have = strings.TrimSpace(strings.TrimPrefix(string(out), "v"))
+	}
+	return st
+}
+
+// toolLocators is every external program irgo runs, and the code that already
+// knows where it is.
+//
+// Each entry calls the owning file's resolver rather than rebuilding a path.
+// doctor used to work out node's location itself and got it wrong two ways, so
+// it could name a binary no build would use. Nothing here derives anything: a
+// tool's own file decides, and doctor reports what it says.
+//
+// Every developer's machine answers "where is everything" with one command,
+// and adding a tool means adding one line.
+func toolLocators() []toolStatus {
+	sdk := androidHome()
+
+	// found reports a path when something is actually there, and how to get
+	// it when it is not.
+	found := func(name, path, how string, ensure func() error) toolStatus {
+		st := toolStatus{name: name, ensure: ensure, how: how}
+		if path == "" {
 			return st
 		}
+		if _, err := os.Stat(path); err != nil {
+			return st
+		}
+		st.path = path
+		return st
 	}
-	if nodeWorks(bin) {
-		st.path = bin
-		// node --version is reliable, unlike the Go tools'.
-		if out, err := exec.Command(bin, "--version").Output(); err == nil {
-			st.have = strings.TrimSpace(strings.TrimPrefix(string(out), "v"))
+	// onPath is for tools found by name. ensure may be nil: irgo cannot
+	// install Xcode or a system C compiler, and says so instead.
+	onPath := func(name, how string, ensure func() error) toolStatus {
+		st := toolStatus{name: name, ensure: ensure, how: how}
+		if p, err := exec.LookPath(name); err == nil && runs(p) {
+			st.path = p
+		}
+		return st
+	}
+
+	rows := append(goToolStatuses(), nodeStatus())
+
+	// Tools mise provides, resolved through mise rather than by name.
+	//
+	// sops was in the platform list, so doctor looked it up on PATH, found a
+	// shim that fails with "no version is set", and reported absent — while
+	// mise had the binary all along. A tool mise provides has to be asked of
+	// mise, like every other row here.
+	rows = append(rows, miseRow("sops"))
+
+	// Downloaded by irgo.
+	rows = append(rows,
+		found("tailwindcss", tailwindPath(), howDownload, func() error {
+			_, err := ensureTailwind()
+			return err
+		}),
+	)
+
+	// The Android toolchain, each from the function that owns it.
+	jdk, _ := detectJDK17(false)
+	androidTools := func() error { return ensureAndroidToolchain(false, "") }
+	rows = append(rows,
+		found("jdk", jdk, howDownload, func() error {
+			_, ok := detectJDK17(true)
+			if !ok {
+				return fmt.Errorf("could not install a JDK 17")
+			}
+			return nil
+		}),
+		found("sdkmanager", locateSdkmanager(sdk), howAndroid, androidTools),
+		found("avdmanager", locateAvdmanager(sdk), howAndroid, androidTools),
+		found("adb", adbBin(), howAndroid, androidTools),
+		found("emulator", emulatorBin(sdk), howAndroid, func() error { return ensureAndroidToolchain(true, "") }),
+		found("ndk", ndkDir(sdk), howAndroid, androidTools),
+	)
+
+	// Provided by the platform or the developer. irgo cannot install these,
+	// but where they are is exactly what someone debugging a build needs.
+	for _, name := range platformTools() {
+		rows = append(rows, onPath(name, platformHow(name), platformEnsure(name)))
+	}
+
+	pruneStaleMarkers(rows)
+
+	// Everything below needs the finished set, so it runs here rather than in
+	// whichever command happens to call this. An earlier version attached
+	// removal inside doctor's printer, so `tools remove` — which reads this
+	// function directly — found nothing removable at all.
+	for i := range rows {
+		// Where it actually came from beats where it would come from.
+		if src := sourceOf(rows[i].name, rows[i].path); src != "" {
+			rows[i].how = src
+		}
+		// Disk, for the things irgo put there: 485 MB of Node and JDK sat in
+		// ~/.irgo duplicating what mise had, and only du could tell you.
+		rows[i].size = irgoDiskUse(rows[i].path)
+		// The inverse of how it was installed.
+		attachRemove(&rows[i])
+		// Ask the tool itself when irgo has no marker for it.
+		if rows[i].have == "" {
+			rows[i].have = toolVersion(rows[i].path)
+		}
+	}
+	return rows
+}
+
+// pruneStaleMarkers drops records of tools that are no longer there.
+//
+// ~/.irgo/tools says what irgo installed, which is the only way to know that a
+// mise or GOBIN copy is irgo's rather than the developer's. Nothing swept it,
+// so it accumulated: a marker for node long after that directory was deleted,
+// and one for entr, a tool irgo no longer uses at all.
+//
+// A marker for something absent is not harmless. It is the thing `tools
+// remove` consults to decide what it may delete.
+func pruneStaleMarkers(rows []toolStatus) {
+	dir := irgoToolsDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	known := map[string]bool{}
+	for _, r := range rows {
+		if r.path != "" {
+			known[r.name] = true
+		}
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue // the mise markers, pruned by spec below
+		}
+		name := e.Name()
+		if known[name] || isHostPackage(name) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(dir, name))
+	}
+
+}
+
+// isHostPackage keeps markers for brew and apt packages, which are not tools
+// in the table and have no path to check.
+func isHostPackage(name string) bool {
+	for _, p := range hostPackageKeys() {
+		if p == name {
+			return true
+		}
+	}
+	return false
+}
+
+// runs reports whether a binary actually executes.
+//
+// Existing is not the same as working: a version manager's shim is a real file
+// that fails with "no version is set" when nothing selects one. doctor named
+// the sops shim as though a build could use it, which is the same mistake
+// nodeWorks was written to stop.
+func runs(path string) bool {
+	if path == "" {
+		return false
+	}
+	// Only shims are distrusted. Testing every binary was worse than the bug:
+	// go, codesign and security do not take --version, exited non-zero, and
+	// doctor called three working tools ABSENT.
+	if !strings.Contains(path, string(filepath.Separator)+"shims"+string(filepath.Separator)) {
+		return true
+	}
+	out, err := exec.Command(path, "--version").CombinedOutput()
+	if err == nil {
+		return true
+	}
+	// A shim with nothing selected says so, and cannot be used by a build.
+	return !strings.Contains(string(out), "No version is set")
+}
+
+// toolVersion asks a binary what it is.
+//
+// The marker irgo writes only exists for tools irgo installed, which after
+// mise took over most of them left fifteen of twenty-two rows blank. Running
+// the tool covers the rest — carefully, because air and gobind have no version
+// flag and their usage text contains a Go version that is not theirs.
+func toolVersion(path string) string {
+	if path == "" {
+		return ""
+	}
+	out, err := exec.Command(path, "--version").Output()
+	if err != nil {
+		return ""
+	}
+	// The first token shaped like a version, and nothing else. "tailwindcss
+	// v4.3.3" and "git version 2.51.0" both land here; a usage banner does not.
+	for _, field := range strings.Fields(string(out)) {
+		v := strings.TrimPrefix(strings.TrimSuffix(field, ","), "v")
+		if versionShaped(v) {
+			return v
+		}
+	}
+	return ""
+}
+
+// versionShaped is a digit, a dot, a digit — deliberately strict, so a path or
+// a date does not read as a version.
+func versionShaped(s string) bool {
+	dots, digits := 0, 0
+	for _, r := range s {
+		switch {
+		case r == '.':
+			dots++
+		case r >= '0' && r <= '9':
+			digits++
+		case r == '-' || r == '+' || (r >= 'a' && r <= 'z'):
+			// build metadata, allowed after the numbers
+		default:
+			return false
+		}
+	}
+	if dots < 1 || digits < 2 || s == "" || s[0] < '0' || s[0] > '9' {
+		return false
+	}
+	// A trailing dot is not a version: xcrun prints "xcrun version 72." and
+	// that read as 72.
+	return s[len(s)-1] != '.'
+}
+
+// attachRemove gives a row the inverse of how it was installed.
+//
+// Only what irgo installed: the markers decide. A mise tool is uninstalled by
+// the exact spec irgo asked for, never by name, so a developer's own version
+// is never a candidate.
+func attachRemove(r *toolStatus) {
+	name := r.name
+	if spec, ok := miseSpecFor(name); ok && installedViaMise(spec) {
+		r.remove = func() error {
+			mise, ok := miseCmd()
+			if !ok {
+				return fmt.Errorf("mise is gone, so %s cannot be uninstalled through it", name)
+			}
+			if err := exec.Command(mise, "uninstall", spec).Run(); err != nil {
+				return err
+			}
+			return nil
+		}
+		return
+	}
+	// irgo's own directories.
+	if r.path != "" && strings.HasPrefix(r.path, irgoHome()) {
+		dir := irgoOwnedDir(r.path)
+		r.remove = func() error {
+			if err := os.RemoveAll(dir); err != nil {
+				return err
+			}
+			clearToolMarker(name)
+			return nil
+		}
+		return
+	}
+	if toolInstalledByIrgo(name) && r.how == howGoInstall {
+		r.remove = func() error {
+			removeToolPath(name)
+			clearToolMarker(name)
+			return nil
+		}
+	}
+}
+
+// irgoOwnedDir is what removing a tool should delete: its own directory under
+// ~/.irgo, or the single file when it lives in ~/.irgo/bin.
+func irgoOwnedDir(path string) string {
+	if filepath.Dir(path) == irgoBinDir() {
+		return path
+	}
+	dir := path
+	for filepath.Dir(dir) != irgoHome() && filepath.Dir(dir) != "/" && dir != "" {
+		dir = filepath.Dir(dir)
+	}
+	return dir
+}
+
+// miseRow resolves a tool through mise, at irgo's pin.
+func miseRow(name string) toolStatus {
+	st := toolStatus{
+		name:   name,
+		how:    howGoInstall,
+		ensure: func() error { return ensureGoTool(name) },
+	}
+	spec, ok := miseSpec(name)
+	if !ok {
+		return st
+	}
+	if mise, have := miseCmd(); have {
+		st.path = miseWhere(mise, spec, name)
+	}
+	if st.path == "" {
+		// Not through mise: whatever is on PATH, if it runs.
+		if p, err := exec.LookPath(name); err == nil && runs(p) {
+			st.path = p
 		}
 	}
 	return st
 }
 
+// platformHow says where a host tool comes from.
+func platformHow(name string) string {
+	switch name {
+	case "sops":
+		return howGoInstall
+	case "gcc", "pkg-config", "x86_64-w64-mingw32-gcc":
+		return howHostPkg
+	case "mise":
+		return howDownload
+	case "go":
+		return howPrereq
+	}
+	return howPlatform
+}
+
+// platformEnsure returns how to obtain a host tool, or nil when irgo cannot.
+//
+// sops is a Go program, so `go install` reaches it. The rest — Xcode, a C
+// compiler, git — come from the platform, and claiming otherwise would send
+// someone to run a command that cannot work.
+func platformEnsure(name string) func() error {
+	switch name {
+	case "mise":
+		return func() error { _, err := ensureMise(); return err }
+	case "sops":
+		return func() error { return ensureGoTool("sops") }
+	case "gcc", "pkg-config":
+		return func() error { return ensureOSPackage(name) }
+	case "x86_64-w64-mingw32-gcc":
+		return func() error { return ensureOSPackage("mingw-w64") }
+	}
+	return nil
+}
+
+// platformTools are the host programs irgo runs but does not provide. Listed
+// per OS, because naming xcrun on Linux would report a permanent absence.
+func platformTools() []string {
+	// mise first: on a machine that uses it, most rows above resolve to a
+	// path inside its installs directory, so it is the tool that explains
+	// where the others came from.
+	common := []string{"mise", "go", "git"}
+	switch runtime.GOOS {
+	case "darwin":
+		// mingw is the Windows cross-compiler. `tools remove` offered it back
+		// while doctor never mentioned it, so the only way to learn irgo had
+		// installed it was to try deleting things.
+		return append(common, "xcrun", "xcodebuild", "codesign", "security",
+			"clang", "x86_64-w64-mingw32-gcc")
+	case "linux":
+		return append(common, "gcc", "pkg-config", "x86_64-w64-mingw32-gcc")
+	case "windows":
+		return append(common, "powershell")
+	}
+	return common
+}
+
 // printToolVersions writes the section.
 func printToolVersions() {
-	rows := append(goToolStatuses(), nodeStatus())
+	rows := toolLocators()
 
 	w := 0
 	for _, r := range rows {
@@ -112,23 +596,42 @@ func printToolVersions() {
 		}
 	}
 
+	// Width for the "how" column too, so the three read as columns.
+	hw := 0
+	for _, r := range rows {
+		if len(r.how) > hw {
+			hw = len(r.how)
+		}
+	}
+
 	fmt.Println()
-	fmt.Println("Tools irgo installs:")
+	fmt.Println("Tools — where they are, and where they come from:")
 	var drifted []string
 	for _, r := range rows {
-		switch {
-		case r.path == "":
-			fmt.Printf("  %-*s  %-12s  installed when a build needs it\n", w, r.name, "absent")
-		case r.have == "":
-			// Present but not installed by irgo, so there is no record of what
-			// it is and no honest claim to make about it.
-			fmt.Printf("  %-*s  %-12s  %s\n", w, r.name, "yours", r.path)
-		case r.want != "" && !versionMatches(r.have, r.want):
-			fmt.Printf("  %-*s  %-12s  irgo pins %s\n", w, r.name, r.have, r.want)
-			drifted = append(drifted, r.name)
-		default:
-			fmt.Printf("  %-*s  %-12s  %s\n", w, r.name, r.have, whose(r))
+		// One line, one format. Five near-identical Printf calls differed only
+		// in the last two columns, which is how the path came to be missing
+		// from one of them.
+		// One meaning per column: what it is, where it came from, which
+		// version, where it lives. The version column used to say "yours",
+		// which after the source column became derived was the same word
+		// twice and a version nowhere.
+		state, note := r.have, r.path
+		if state == "" {
+			state = "-"
 		}
+		switch {
+		case r.path == "" && r.ensure == nil:
+			state, note = "-", "ABSENT — install it yourself"
+		case r.path == "":
+			state, note = "-", "absent — arrives when a build needs it"
+		case r.want != "" && r.have != "" && !versionMatches(r.have, r.want):
+			note = r.path + " — irgo pins " + r.want
+			drifted = append(drifted, r.name)
+		}
+		if r.size != "" {
+			note = r.size + "  " + note
+		}
+		fmt.Printf("  %-*s  %-*s  %-12s  %s\n", w, r.name, hw, r.how, state, note)
 	}
 
 	if len(drifted) > 0 {
@@ -154,13 +657,4 @@ func versionMatches(have, want string) bool {
 		return true
 	}
 	return false
-}
-
-// whose says where a tool came from, because "irgo installed this" and "you
-// installed this" have different consequences for `tools remove`.
-func whose(r toolStatus) string {
-	if r.managed {
-		return "installed by irgo"
-	}
-	return r.path
 }

--- a/cmd/irgo/tools_ensure_test.go
+++ b/cmd/irgo/tools_ensure_test.go
@@ -83,9 +83,11 @@ func TestRemovalCoversWhatIrgoInstalled(t *testing.T) {
 			t.Errorf("%s is in %s but nothing offers to remove it", row.name, irgoHome())
 		}
 	}
-	if removable == 0 {
-		t.Error("nothing at all is removable, which cannot be right on a machine irgo has built on")
-	}
+	// Nothing removable is the correct answer on a machine irgo has never
+	// installed anything on — a fresh CI runner, for one. The invariant is
+	// that what irgo installed is offered back, which the loop above checks;
+	// asserting a non-zero count assumed a developer's machine and failed
+	// everywhere else.
 	t.Logf("%d tools removable", removable)
 }
 

--- a/cmd/irgo/tools_ensure_test.go
+++ b/cmd/irgo/tools_ensure_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestEveryToolCanBeObtainedOrSaysWhyNot — the whole ensure idea is that a
+// call needing a tool gets one. A row with no path and no way to get it is a
+// dead end someone hits mid-build with nothing to do about it.
+//
+// go is the exception on purpose: it compiles the CLI, so it is there before
+// irgo runs at all. CI installs it the same way.
+func TestEveryToolCanBeObtainedOrSaysWhyNot(t *testing.T) {
+	provided := map[string]string{
+		"go":         "compiles irgo itself, so it is a prerequisite",
+		"git":        "ships with the platform's developer tools",
+		"mise":       "optional; irgo uses what it finds",
+		"xcrun":      "part of Xcode, which only Apple can install",
+		"xcodebuild": "part of Xcode",
+		"codesign":   "part of Xcode",
+		"security":   "part of macOS",
+		"clang":      "part of the Xcode command line tools",
+		"powershell": "part of Windows",
+	}
+	for _, row := range toolLocators() {
+		if row.ensure != nil {
+			continue
+		}
+		if _, ok := provided[row.name]; !ok {
+			t.Errorf("%s has no ensure function and no recorded reason — "+
+				"either give it one, or record why irgo cannot provide it", row.name)
+		}
+	}
+}
+
+// TestInstallableToolsAreReportedByDoctor — install and doctor read the same
+// table, so a tool cannot be installable without being visible.
+func TestInstallableToolsAreReportedByDoctor(t *testing.T) {
+	rows := toolLocators()
+	if len(rows) < 15 {
+		t.Fatalf("doctor reports %d tools — it used to be five, and the point was to cover them all", len(rows))
+	}
+	var installable int
+	for _, r := range rows {
+		if r.ensure != nil {
+			installable++
+		}
+	}
+	if installable == 0 {
+		t.Fatal("no tool can be installed, which cannot be right")
+	}
+	t.Logf("%d tools reported, %d of them irgo can install", len(rows), installable)
+}
+
+// TestEveryToolSaysWhereItComesFrom — doctor exists so nobody has to read the
+// source to learn how a tool arrives. A blank column sends them back to it.
+func TestEveryToolSaysWhereItComesFrom(t *testing.T) {
+	for _, row := range toolLocators() {
+		if row.how == "" {
+			t.Errorf("%s does not say where it comes from", row.name)
+		}
+	}
+}
+
+// TestRemovalCoversWhatIrgoInstalled — install and remove read the same table,
+// so anything irgo put on the machine has to be offered back. The first
+// version of this attached removal inside doctor's printer, so `tools remove`
+// found nothing removable at all and would have left every download behind.
+func TestRemovalCoversWhatIrgoInstalled(t *testing.T) {
+	var removable int
+	for _, row := range toolLocators() {
+		if row.remove != nil {
+			removable++
+		}
+		// A row irgo can install, that is present, and that lives somewhere
+		// irgo owns, must be removable.
+		if row.ensure != nil && row.path != "" &&
+			strings.HasPrefix(row.path, irgoHome()) && row.remove == nil {
+			t.Errorf("%s is in %s but nothing offers to remove it", row.name, irgoHome())
+		}
+	}
+	if removable == 0 {
+		t.Error("nothing at all is removable, which cannot be right on a machine irgo has built on")
+	}
+	t.Logf("%d tools removable", removable)
+}
+
+// TestABrokenShimIsNotReportedAsPresent — a version manager's shim is a real
+// file that fails with "no version is set" when nothing selects one. doctor
+// named the sops shim as a usable path, which is a build failure waiting in a
+// column that claims everything is fine.
+func TestABrokenShimIsNotReportedAsPresent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stub is POSIX")
+	}
+	dir := filepath.Join(t.TempDir(), "shims")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	broken := filepath.Join(dir, "sometool")
+	if err := os.WriteFile(broken,
+		[]byte("#!/bin/sh\necho 'mise ERROR No version is set for shim: sometool' >&2\nexit 1\n"),
+		0o755); err != nil {
+		t.Fatal(err)
+	}
+	if runs(broken) {
+		t.Error("a shim with no version selected was reported as usable")
+	}
+
+	working := filepath.Join(dir, "goodtool")
+	if err := os.WriteFile(working, []byte("#!/bin/sh\necho v1.2.3\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !runs(working) {
+		t.Error("a working shim was rejected")
+	}
+
+	// Everything outside a shims directory is trusted: go, codesign and
+	// security do not take --version, and testing them called three working
+	// tools absent.
+	if !runs("/usr/bin/codesign") {
+		t.Error("a real binary that does not take --version was rejected")
+	}
+}
+
+// TestVersionParsingRejectsJunk — "xcrun version 72." read as 72.
+func TestVersionParsingRejectsJunk(t *testing.T) {
+	for _, bad := range []string{"72.", "", "abc", "/usr/bin/x", "1", "2026-08-07"} {
+		if versionShaped(bad) {
+			t.Errorf("%q read as a version", bad)
+		}
+	}
+	for _, good := range []string{"4.3.3", "22.14.0", "0.3.977", "1.0.41", "2026.8.1"} {
+		if !versionShaped(good) {
+			t.Errorf("%q did not read as a version", good)
+		}
+	}
+}

--- a/cmd/irgo/tools_host_packages.go
+++ b/cmd/irgo/tools_host_packages.go
@@ -90,6 +90,17 @@ func (p osPackage) pkgNameFor(mgr string) string {
 	return ""
 }
 
+// hostPackageKeys names every package irgo can install through the host's
+// package manager. Their markers have no path to check, so marker pruning
+// needs to know them by name.
+func hostPackageKeys() []string {
+	var out []string
+	for _, p := range osPackages() {
+		out = append(out, p.key)
+	}
+	return out
+}
+
 func findOSPackage(key string) (osPackage, bool) {
 	for _, p := range osPackages() {
 		if p.key == key {

--- a/cmd/irgo/tools_mise.go
+++ b/cmd/irgo/tools_mise.go
@@ -1,0 +1,205 @@
+// mise, asked first when irgo has to install something.
+//
+// irgo downloaded 176 MB of Node and 309 MB of JDK onto a machine whose mise
+// already had both. That is the disruptive way round: a second copy of a
+// toolchain, in a directory only irgo knows about, that the developer's own
+// version manager cannot see or clean up.
+//
+// So when a tool is missing and mise can provide it, mise does. irgo's own
+// downloader stays as the fallback, because mise cannot reach everything —
+// templ and gomobile are `go install`, tailwindcss is not in the registry, and
+// the Android NDK needs the exact pin irgo holds rather than whatever a plugin
+// resolves to.
+//
+// Two rules:
+//
+//   - Never install a second mise. A host that has one keeps it — PATH, then
+//     mise's own install location, then irgo's, before anything is fetched.
+//     When a tool's install path goes through mise and the host has none, one
+//     static binary is downloaded: at that point mise is not optional, it is
+//     what stands between the developer and a working build.
+//   - Never touch the user's config. `mise use -g` rewrites config.toml.
+//     `mise install` plus `mise where` gets the same binary and leaves it alone.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// pinMise is bootstrapped only when a tool needs mise and the host has none.
+// irgo never upgrades a mise it did not install.
+const pinMise = "v2026.8.2"
+
+// ensureMise finds mise, or installs one.
+//
+// Called when a tool's install path goes through mise: at that point mise is
+// not optional, it is the thing standing between the developer and a working
+// build. Downloading one static binary is a smaller imposition than failing.
+//
+// A host that already has mise keeps it — three checks before anything is
+// fetched, so nobody ends up with two.
+func ensureMise() (string, error) {
+	if p, ok := miseCmd(); ok {
+		return p, nil
+	}
+	bin := filepath.Join(irgoBinDir(), "mise")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	asset, err := miseAsset()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		return "", err
+	}
+	fmt.Printf("mise not found — downloading %s...\n", pinMise)
+
+	// To .part then rename, so an interrupted download cannot leave something
+	// that later looks installed. Same as Tailwind's.
+	tmp := bin + ".part"
+	if err := downloadFile("https://github.com/jdx/mise/releases/download/"+pinMise+"/"+asset, tmp); err != nil {
+		os.Remove(tmp)
+		return "", fmt.Errorf("downloading mise: %w", err)
+	}
+	if err := os.Chmod(tmp, 0o755); err != nil {
+		os.Remove(tmp)
+		return "", err
+	}
+	if err := os.Rename(tmp, bin); err != nil {
+		os.Remove(tmp)
+		return "", err
+	}
+	markToolInstalled("mise")
+	return bin, nil
+}
+
+// miseAsset maps the host to a release asset. mise publishes bare binaries
+// beside the archives, so there is nothing to extract.
+func miseAsset() (string, error) {
+	var host, arch string
+	switch runtime.GOOS {
+	case "darwin":
+		host = "macos"
+	case "linux":
+		host = "linux"
+	case "windows":
+		return "mise-" + pinMise + "-windows-x64.exe", nil
+	default:
+		return "", fmt.Errorf("no mise build for %s", runtime.GOOS)
+	}
+	switch runtime.GOARCH {
+	case "arm64":
+		arch = "arm64"
+	case "amd64":
+		arch = "x64"
+	default:
+		return "", fmt.Errorf("no mise build for %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+	return fmt.Sprintf("mise-%s-%s-%s", pinMise, host, arch), nil
+}
+
+// miseCmd returns mise if this machine already has it, without installing.
+func miseCmd() (string, bool) {
+	if p, err := exec.LookPath("mise"); err == nil {
+		return p, true
+	}
+	// mise's own installer puts it here, and it is not always on PATH.
+	p := filepath.Join(homeDir(), ".local", "bin", "mise")
+	if pathExists(p) {
+		return p, true
+	}
+	return "", false
+}
+
+// miseTool returns a tool's binary from mise, installing it if mise can.
+//
+// spec is what mise is asked for, with irgo's pin in it — "node@22.14.0",
+// "aqua:tailwindlabs/tailwindcss@4.3.3". Returns "" when mise cannot provide
+// it, which is the caller's signal to fall back to irgo's own download.
+func miseTool(spec, binary string) string {
+	// Installing, not looking: mise is required here, so fetch one if needed.
+	mise, err := ensureMise()
+	if err != nil {
+		return ""
+	}
+	// Already installed: no network, no output, just a path.
+	if p := miseWhere(mise, spec, binary); p != "" {
+		return p
+	}
+	if err := exec.Command(mise, "install", spec).Run(); err != nil {
+		return ""
+	}
+	return miseWhere(mise, spec, binary)
+}
+
+// miseWhere asks where a version lives and finds the binary inside it.
+//
+// `mise where` reports an install directory without consulting or changing
+// which version is active, so this works whether or not the tool is in the
+// developer's config.
+//
+// The binary is searched for rather than assumed. Layouts differ — node uses
+// bin/, an aqua tool sits at the root, some nest a directory deep — and
+// hardcoding bin/ meant tailwindcss silently fell through to irgo's own
+// download while mise had it all along.
+func miseWhere(mise, spec, binary string) string {
+	out, err := exec.Command(mise, "where", spec).Output()
+	if err != nil {
+		return ""
+	}
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		return ""
+	}
+	if runtime.GOOS == "windows" && !strings.HasSuffix(binary, ".exe") {
+		binary += ".exe"
+	}
+	for _, p := range []string{
+		filepath.Join(dir, binary),
+		filepath.Join(dir, "bin", binary),
+	} {
+		if pathExists(p) {
+			return p
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		for _, p := range []string{
+			filepath.Join(dir, e.Name(), binary),
+			filepath.Join(dir, e.Name(), "bin", binary),
+		} {
+			if pathExists(p) {
+				return p
+			}
+		}
+	}
+	return ""
+}
+
+// installedViaMise reports whether the exact version irgo pins is installed.
+//
+// No bookkeeping: the pin is the identity. irgo only ever asks for
+// node@22.14.0, so that is the only node it can remove, and irgo's own source
+// says which one that is. A file recording "irgo installed this" only added
+// the distinction between installing a version and finding it already there —
+// and tools remove prints what it will delete and refuses without
+// confirmation, so a person sees node@22.14.0 before anything happens.
+func installedViaMise(spec string) bool {
+	mise, ok := miseCmd()
+	if !ok {
+		return false
+	}
+	return exec.Command(mise, "where", spec).Run() == nil
+}

--- a/cmd/irgo/tools_node.go
+++ b/cmd/irgo/tools_node.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -26,7 +27,7 @@ import (
 // failing because upstream moved.
 const pinNode = "22.14.0"
 
-func managedNodeHome() string { return filepath.Join(homeDir(), ".irgo", "node") }
+func managedNodeHome() string { return filepath.Join(irgoHome(), "node") }
 
 // nodeBin returns a usable node, provisioning one if needed.
 //
@@ -34,9 +35,24 @@ func managedNodeHome() string { return filepath.Join(homeDir(), ".irgo", "node")
 // that errors when no version is selected reports success to LookPath and then
 // fails, so it is tested rather than trusted.
 func nodeBin(install bool) (string, error) {
+	// The developer's own node, if it is new enough. Never replaced.
 	if p, err := exec.LookPath("node"); err == nil && nodeWorks(p) {
 		return p, nil
 	}
+
+	// mise before irgo's own copy. Every other tool resolves this way, and
+	// node did not only because it was wired first: it preferred ~/.irgo/node
+	// and so kept 165 MB alive that mise already had. Whichever is chosen
+	// here is the one doctor names, so the order is the answer to "which node
+	// is this build using".
+	if mise, ok := miseCmd(); ok {
+		for _, spec := range []string{"node@" + pinNode, "node"} {
+			if bin := miseWhere(mise, spec, "node"); nodeWorks(bin) {
+				return bin, nil
+			}
+		}
+	}
+
 	managed := filepath.Join(managedNodeHome(), "bin", "node")
 	if runtime.GOOS == "windows" {
 		managed = filepath.Join(managedNodeHome(), "node.exe")
@@ -44,25 +60,53 @@ func nodeBin(install bool) (string, error) {
 	if nodeWorks(managed) {
 		return managed, nil
 	}
+
 	if !install {
 		return "", fmt.Errorf("no working node found — irgo can install one into %s", managedNodeHome())
+	}
+	if bin := miseTool("node@"+pinNode, "node"); nodeWorks(bin) {
+		return bin, nil
 	}
 	return installNode()
 }
 
 // nodeWorks reports whether this binary actually runs.
 func nodeWorks(bin string) bool {
+	major, ok := nodeMajor(bin)
+	return ok && major >= minNodeMajor
+}
+
+// minNodeMajor is what wrangler 4 requires.
+//
+// A developer's own node is preferred, but "runs" is not the same as "works":
+// node 18 is still common, wrangler 4 refuses it, and the failure arrives from
+// inside npx looking like a Cloudflare problem. Too old is skipped here, so
+// irgo falls through to mise or its own copy — which leaves the developer's
+// node exactly where it was. irgo never replaces what is on the machine.
+const minNodeMajor = 20
+
+// nodeMajor runs a candidate and reports its major version.
+func nodeMajor(bin string) (int, bool) {
 	if bin == "" {
-		return false
+		return 0, false
 	}
 	if _, err := os.Stat(bin); err != nil {
-		return false
+		return 0, false
 	}
 	out, err := exec.Command(bin, "--version").CombinedOutput()
 	if err != nil {
-		return false
+		return 0, false
 	}
-	return strings.HasPrefix(strings.TrimSpace(string(out)), "v")
+	v := strings.TrimSpace(string(out))
+	if !strings.HasPrefix(v, "v") {
+		return 0, false
+	}
+	major, _, _ := strings.Cut(strings.TrimPrefix(v, "v"), ".")
+	n, err := strconv.Atoi(major)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 // installNode downloads Node into ~/.irgo/node.

--- a/cmd/irgo/tools_node_version_test.go
+++ b/cmd/irgo/tools_node_version_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestOldNodeIsSkippedNotUsed — a developer's own node is preferred, but node
+// 18 is still common and wrangler 4 refuses it. Taking it anyway produces a
+// failure from inside npx that reads like a Cloudflare problem.
+//
+// irgo must skip it and look elsewhere. It must never replace it: what is on
+// the machine is the developer's business.
+func TestOldNodeIsSkippedNotUsed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stub is POSIX")
+	}
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "node")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\necho v18.20.0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if major, ok := nodeMajor(fake); !ok || major != 18 {
+		t.Fatalf("nodeMajor read %d, %v — want 18", major, ok)
+	}
+	if nodeWorks(fake) {
+		t.Errorf("node 18 accepted; wrangler %d+ is required", minNodeMajor)
+	}
+
+	newer := filepath.Join(dir, "newnode")
+	if err := os.WriteFile(newer, []byte("#!/bin/sh\necho v22.14.0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !nodeWorks(newer) {
+		t.Error("node 22 rejected")
+	}
+}
+
+// TestNodeMajorHandlesJunk — a shim that prints an error, or nothing, must not
+// read as a usable node.
+func TestNodeMajorHandlesJunk(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stub is POSIX")
+	}
+	dir := t.TempDir()
+	for name, body := range map[string]string{
+		"empty":   "#!/bin/sh\n",
+		"noV":     "#!/bin/sh\necho 22.14.0\n",
+		"shimErr": "#!/bin/sh\necho 'no version set' >&2; exit 1\n",
+		"garbage": "#!/bin/sh\necho vBANANA\n",
+	} {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := nodeMajor(p); ok {
+			t.Errorf("%s was read as a usable node", name)
+		}
+	}
+	if _, ok := nodeMajor(filepath.Join(dir, "does-not-exist")); ok {
+		t.Error("a missing file was read as a usable node")
+	}
+}

--- a/cmd/irgo/tools_tailwind.go
+++ b/cmd/irgo/tools_tailwind.go
@@ -27,7 +27,23 @@ func tailwindBin() string {
 	if runtime.GOOS == "windows" {
 		name += ".exe"
 	}
-	return filepath.Join(homeDir(), ".irgo", "bin", name)
+	return filepath.Join(irgoBinDir(), name)
+}
+
+// tailwindPath finds an existing Tailwind without installing one.
+//
+// irgo's own copy, then mise's. doctor calls this, so it names the binary a
+// build would use — it was reporting "absent" while builds happily used the
+// one mise had, which is the gap this whole exercise kept turning up.
+func tailwindPath() string {
+	if fi, err := os.Stat(tailwindBin()); err == nil && fi.Mode()&0o111 != 0 {
+		return tailwindBin()
+	}
+	if mise, ok := miseCmd(); ok {
+		return miseWhere(mise, "aqua:tailwindlabs/tailwindcss@"+
+			strings.TrimPrefix(pinTailwind, "v"), "tailwindcss")
+	}
+	return ""
 }
 
 // tailwindAsset maps the host to a release asset name.
@@ -53,8 +69,15 @@ func tailwindAsset() (string, error) {
 // its path. Idempotent: the version is in the filename, so an upgrade fetches
 // a new file rather than silently replacing one that a build may be using.
 func ensureTailwind() (string, error) {
+	if bin := tailwindPath(); bin != "" {
+		return bin, nil
+	}
 	bin := tailwindBin()
-	if fi, err := os.Stat(bin); err == nil && fi.Mode()&0o111 != 0 {
+
+	// mise first, at irgo's pin. aqua has it, which the registry does not say
+	// because that listing is truncated.
+	if bin := miseTool("aqua:tailwindlabs/tailwindcss@"+strings.TrimPrefix(pinTailwind, "v"),
+		"tailwindcss"); bin != "" {
 		return bin, nil
 	}
 
@@ -92,7 +115,7 @@ func ensureTailwind() (string, error) {
 // removeTailwindPath removes the downloaded Tailwind binaries and returns the
 // last path removed, or "" when none were present.
 func removeTailwindPath() string {
-	dir := filepath.Join(homeDir(), ".irgo", "bin")
+	dir := irgoBinDir()
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return ""
@@ -113,7 +136,7 @@ func removeTailwindPath() string {
 
 // removeTailwind is the inverse, for uninstall-tools.
 func removeTailwind() bool {
-	dir := filepath.Join(homeDir(), ".irgo", "bin")
+	dir := irgoBinDir()
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return false

--- a/fnox.toml
+++ b/fnox.toml
@@ -1,0 +1,26 @@
+# Secret resolution for irgo.
+# Repo: github.com/stukennedy/irgo
+#
+# Only the docs site needs credentials, and only to deploy. Everything else —
+# build, run, test, every mobile and desktop target — needs nothing.
+#
+# Values live in the macOS keychain; this file declares the contract. Set with:
+#   fnox set -p keychain CLOUDFLARE_API_TOKEN  <token>
+#   fnox set -p keychain CLOUDFLARE_ACCOUNT_ID <id>
+# (NEVER omit `-p keychain` — without it values get inlined as plaintext.)
+#
+# Deploy the docs site:
+#   fnox exec -- go tool irgo -C docs-templ app deploy cloudflare
+#
+# CI does not use this: GitHub Actions supplies the same two names from
+# repository secrets, which is why the workflow reads them straight from the
+# environment.
+
+[providers.keychain]
+type = "keychain"
+service = "fnox"
+
+[secrets]
+# Shared CF creds — the same names every joeblew999 repo uses, one CF account.
+CLOUDFLARE_API_TOKEN  = { provider = "keychain", value = "CLOUDFLARE_API_TOKEN" }
+CLOUDFLARE_ACCOUNT_ID = { provider = "keychain", value = "CLOUDFLARE_ACCOUNT_ID" }

--- a/pkg/datastarjs/datastarjs.go
+++ b/pkg/datastarjs/datastarjs.go
@@ -20,6 +20,7 @@
 package datastarjs
 
 import (
+	"bytes"
 	_ "embed"
 	"net/http"
 	"strconv"
@@ -34,7 +35,32 @@ import (
 const Version = "v1.0.2"
 
 //go:embed datastar.js
-var script []byte
+var embedded []byte
+
+// script is the bundle with its source-map reference removed.
+//
+// The bundle ends with a //# sourceMappingURL=datastar.js.map comment, and the
+// map is not distributed — Datastar does not publish it and it is not vendored
+// here. A browser only fetches a map when devtools are open, so the dangling
+// reference is invisible in normal use and every irgo project has been serving
+// it. It is not invisible to everything: a headless browser that resolves the
+// comment eagerly fails to compile the whole client, which is how this was
+// found.
+var script = stripSourceMap(embedded)
+
+func stripSourceMap(b []byte) []byte {
+	const marker = "//# sourceMappingURL="
+	i := bytes.LastIndex(b, []byte(marker))
+	if i < 0 {
+		return b
+	}
+	// Keep anything after the comment's line, in case it is not last.
+	rest := b[i:]
+	if nl := bytes.IndexByte(rest, '\n'); nl >= 0 {
+		return append(bytes.Clone(b[:i]), rest[nl+1:]...)
+	}
+	return bytes.TrimRight(b[:i], "\n\r\t ")
+}
 
 // Script returns the Datastar client source, for builds that embed it rather
 // than serve it — the mobile shells read it through the same bridge as

--- a/pkg/datastarjs/datastarjs_test.go
+++ b/pkg/datastarjs/datastarjs_test.go
@@ -62,3 +62,17 @@ func TestGoAndClientAgreeOnTheWireFormat(t *testing.T) {
 		}
 	}
 }
+
+// TestServedClientHasNoDanglingSourceMap — the bundle ships with a
+// //# sourceMappingURL comment and the map is not distributed with it. A
+// browser only resolves that when devtools are open, so every generated
+// project served a dead reference without anyone noticing. Anything that
+// resolves it eagerly fails to compile the client at all.
+func TestServedClientHasNoDanglingSourceMap(t *testing.T) {
+	if strings.Contains(string(Script()), "sourceMappingURL") {
+		t.Error("the served client still references a source map that is not shipped")
+	}
+	if !strings.Contains(string(Script()), "datastar") {
+		t.Error("stripping the source map appears to have eaten the bundle")
+	}
+}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -1,0 +1,476 @@
+// Package secrets resolves the secrets a command needs, without a wrapper.
+//
+// Deploying and signing need credentials, and the usual answer is to put
+// another language's binary in front of every command: `fnox exec -- irgo app
+// deploy cloudflare`. That works until someone forgets it, and forgetting it
+// fails as "no API token" rather than "you did not run the wrapper".
+//
+// So irgo reads the contract itself. It is the same fnox.toml other repos
+// already declare and the same keychain entries fnox already writes — this is
+// interoperability, not a replacement. fnox is a maintained tool with leases,
+// sync, a TUI and half a dozen providers; reimplementing it would be a second
+// thing to own. A program only ever needs the read path, and the read path is
+// this file.
+//
+// Two providers cover what a build needs. keychain is for a laptop: nothing
+// touches the repository. sops is for CI: the secrets are encrypted in the
+// repository and the runner holds one key. Both are read here; writing them
+// stays with fnox and sops, which are better at it.
+//
+//	fnox set -p keychain CLOUDFLARE_API_TOKEN <token>
+//	sops encrypt --in-place secrets.enc.yaml
+//
+// Values are never logged. The only thing this package will say about a secret
+// is whether it resolved.
+package secrets
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// ConfigName is the file that declares which secrets a repository uses.
+const ConfigName = "fnox.toml"
+
+// Secret is one declared secret: where to get it, and what to ask for.
+type Secret struct {
+	Name     string
+	Provider string
+	Value    string
+}
+
+// Config is a parsed fnox.toml.
+type Config struct {
+	// Path is the file this came from, for error messages.
+	Path string
+	// Providers maps a provider name to its settings, e.g. keychain -> service.
+	Providers map[string]map[string]string
+	// Secrets are declared in file order, so failures report predictably.
+	Secrets []Secret
+
+	// Envs holds per-environment overlays, keyed by name, declared as
+	// [env.staging.secrets]. Same names, different sources.
+	Envs map[string][]Secret
+
+	// EnvNames is the declared environments in file order, for listing.
+	EnvNames []string
+}
+
+// For returns the config as one environment sees it: the base secrets, with
+// any the environment redeclares replaced.
+//
+// Real deployments are the same application against different backing
+// services, and the difference is almost never which secrets exist — it is
+// which values they take. So an environment overlays rather than replaces, and
+// a name declared once at the top keeps working everywhere.
+func (c *Config) For(env string) *Config {
+	if env == "" || len(c.Envs[env]) == 0 {
+		return c
+	}
+	override := map[string]Secret{}
+	for _, s := range c.Envs[env] {
+		override[s.Name] = s
+	}
+	out := *c
+	out.Secrets = nil
+	seen := map[string]bool{}
+	for _, s := range c.Secrets {
+		if o, ok := override[s.Name]; ok {
+			s = o
+			seen[s.Name] = true
+		}
+		out.Secrets = append(out.Secrets, s)
+	}
+	// Secrets only one environment has — a staging-only feature flag.
+	for _, s := range c.Envs[env] {
+		if !seen[s.Name] {
+			out.Secrets = append(out.Secrets, s)
+		}
+	}
+	return &out
+}
+
+// HasEnv reports whether an environment is declared, so a typo in --env is an
+// error rather than silently falling back to production values.
+func (c *Config) HasEnv(env string) bool {
+	_, ok := c.Envs[env]
+	return ok
+}
+
+// Find locates the nearest fnox.toml at or above dir.
+//
+// Walking up matters because commands run from a subdirectory: the docs site
+// is built from docs-templ, and the credentials belong to the repository.
+func Find(dir string) (string, bool) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", false
+	}
+	for {
+		candidate := filepath.Join(abs, ConfigName)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, true
+		}
+		parent := filepath.Dir(abs)
+		if parent == abs {
+			return "", false
+		}
+		abs = parent
+	}
+}
+
+// Load parses the nearest fnox.toml. A missing file is not an error: most
+// projects have no secrets, and every command has to work without one.
+func Load(dir string) (*Config, bool, error) {
+	path, ok := Find(dir)
+	if !ok {
+		return nil, false, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false, err
+	}
+	cfg, err := parse(string(data))
+	if err != nil {
+		return nil, false, fmt.Errorf("%s: %w", path, err)
+	}
+	cfg.Path = path
+	return cfg, true, nil
+}
+
+// Apply resolves every declared secret and puts it in the environment.
+//
+// An existing environment variable always wins, so CI — which supplies the
+// same names from repository secrets — is unaffected, and so is anyone who
+// exported one by hand for a single command.
+//
+// Returns the names it set. A secret that cannot be resolved is reported and
+// skipped rather than fatal: a command that does not need it should still run,
+// and a command that does will fail with its own, better message.
+func Apply(dir, env string) (applied []string, skipped map[string]error, err error) {
+	cfg, ok, err := Load(dir)
+	if err != nil || !ok {
+		return nil, nil, err
+	}
+	if env != "" && !cfg.HasEnv(env) {
+		return nil, nil, fmt.Errorf("%s declares no environment %q", cfg.Path, env)
+	}
+	cfg = cfg.For(env)
+	skipped = map[string]error{}
+	for _, s := range cfg.Secrets {
+		if _, present := os.LookupEnv(s.Name); present {
+			continue
+		}
+		value, err := cfg.resolve(s)
+		if err != nil {
+			skipped[s.Name] = err
+			continue
+		}
+		if value == "" {
+			skipped[s.Name] = fmt.Errorf("resolved to an empty value")
+			continue
+		}
+		if err := os.Setenv(s.Name, value); err != nil {
+			skipped[s.Name] = err
+			continue
+		}
+		applied = append(applied, s.Name)
+	}
+	return applied, skipped, nil
+}
+
+// Uses reports whether any declared secret needs the given provider type.
+//
+// Lets a caller install a tool only when the config asks for it: a project
+// keeping its secrets in a keychain should never be told about sops.
+func (c *Config) Uses(kind string) bool {
+	for _, s := range c.Secrets {
+		t := s.Provider
+		if declared := c.Providers[s.Provider]["type"]; declared != "" {
+			t = declared
+		}
+		if t == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// resolve fetches one secret from its provider.
+func (c *Config) resolve(s Secret) (string, error) {
+	kind := s.Provider
+	settings := c.Providers[s.Provider]
+	if t := settings["type"]; t != "" {
+		kind = t
+	}
+
+	switch kind {
+	case "keychain":
+		service := settings["service"]
+		if service == "" {
+			service = "fnox"
+		}
+		return keychain(service, s.Value)
+	case "sops":
+		file := settings["file"]
+		if file == "" {
+			return "", fmt.Errorf("the %q provider needs a file = \"...\"", s.Provider)
+		}
+		return c.sops(settings, file, s.Value)
+	case "env":
+		v, ok := os.LookupEnv(s.Value)
+		if !ok {
+			return "", fmt.Errorf("$%s is not set", s.Value)
+		}
+		return v, nil
+	case "", "plain", "literal":
+		return s.Value, nil
+	default:
+		return "", fmt.Errorf("provider %q is not one this reads — "+
+			"use fnox for it, or declare a keychain entry", kind)
+	}
+}
+
+// sops decrypts a key out of a SOPS-encrypted file.
+//
+// The binary rather than the library, deliberately. SOPS is Go and importing
+// github.com/getsops/sops/v3/decrypt would be the obvious move, but it brings
+// the AWS, GCP, Azure and Vault SDKs with it: irgo goes from 48 modules to
+// 341, and every project that runs `go tool irgo` carries them. Shelling out
+// costs one exec and nothing else, and `go install github.com/getsops/sops/v3`
+// is how you get it.
+//
+// This is the provider to use when secrets must reach CI: a SOPS file is
+// encrypted and committed, and CI needs one key rather than a keychain.
+func (c *Config) sops(settings map[string]string, file, key string) (string, error) {
+	path := file
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(filepath.Dir(c.Path), file)
+	}
+	if _, err := os.Stat(path); err != nil {
+		return "", fmt.Errorf("%s: no such file", file)
+	}
+	cmd := exec.Command("sops", "decrypt", "--extract", extractPath(key), path)
+	cmd.Env = os.Environ()
+
+	// The age key can itself be a declared secret, which is the arrangement
+	// worth having: one key in the keychain, everything else encrypted in the
+	// repository. Passing it explicitly rather than relying on it happening to
+	// be resolved first — declaration order is not something a config file
+	// should have to get right.
+	if name := settings["age_key"]; name != "" {
+		value, err := c.resolveNamed(name)
+		if err != nil {
+			return "", fmt.Errorf("the age key for %s: %w", file, err)
+		}
+		cmd.Env = append(cmd.Env, "SOPS_AGE_KEY="+value)
+	}
+
+	out, err := cmd.Output()
+	if err != nil {
+		if _, lookErr := exec.LookPath("sops"); lookErr != nil {
+			return "", fmt.Errorf("sops is not installed — " +
+				"go install github.com/getsops/sops/v3/cmd/sops@latest")
+		}
+		return "", fmt.Errorf("sops could not read %s from %s "+
+			"(is the decryption key available?)", key, file)
+	}
+	return strings.TrimRight(string(out), "\r\n"), nil
+}
+
+// resolveNamed resolves another declared secret by name, for a provider that
+// needs one — the age key a sops file is encrypted to.
+//
+// A sops-backed key would be a cycle: the key needed to decrypt the file
+// cannot live in the file. Refused rather than recursed.
+func (c *Config) resolveNamed(name string) (string, error) {
+	if v, ok := os.LookupEnv(name); ok && v != "" {
+		return v, nil
+	}
+	for _, s := range c.Secrets {
+		if s.Name != name {
+			continue
+		}
+		kind := s.Provider
+		if t := c.Providers[s.Provider]["type"]; t != "" {
+			kind = t
+		}
+		if kind == "sops" {
+			return "", fmt.Errorf("%s is itself a sops secret — the key to a file cannot live in it", name)
+		}
+		return c.resolve(s)
+	}
+	return "", fmt.Errorf("%s is not declared in [secrets]", name)
+}
+
+// extractPath turns a dotted key into the index expression sops wants:
+// "cloudflare.api_token" becomes ["cloudflare"]["api_token"].
+func extractPath(key string) string {
+	var b strings.Builder
+	for _, part := range strings.Split(key, ".") {
+		b.WriteString(`["` + part + `"]`)
+	}
+	return b.String()
+}
+
+// keychain reads a generic password from the platform's own store.
+func keychain(service, account string) (string, error) {
+	if runtime.GOOS != "darwin" {
+		return "", fmt.Errorf("keychain lookups need macOS; set $%s in the environment instead", account)
+	}
+	out, err := exec.Command("security", "find-generic-password",
+		"-s", service, "-a", account, "-w").Output()
+	if err != nil {
+		// Both forms, because irgo does not need fnox: reading is this
+		// function, and fnox is only how a human writes the entry. Someone
+		// without it should not be blocked on installing a Rust toolchain to
+		// set one password.
+		return "", fmt.Errorf("not in the %q keychain. Set it with either:\n"+
+			"    fnox set -p keychain %s        (prompts, nothing in shell history)\n"+
+			"    security add-generic-password -U -s %s -a %s -w",
+			service, account, service, account)
+	}
+	return strings.TrimRight(string(out), "\r\n"), nil
+}
+
+// parse reads the subset of TOML fnox.toml uses: [providers.<name>] tables and
+// a [secrets] table of inline tables.
+//
+// Hand-rolled for the same reason the package config parser is: this is the
+// only TOML the CLI reads, the shape is fixed, and a dependency for it would
+// be carried by every project that builds irgo.
+func parse(src string) (*Config, error) {
+	cfg := &Config{Providers: map[string]map[string]string{}, Envs: map[string][]Secret{}}
+	section := ""
+
+	for i, raw := range strings.Split(src, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.TrimSpace(line[1 : len(line)-1])
+			if name, ok := strings.CutPrefix(section, "providers."); ok {
+				if _, exists := cfg.Providers[name]; !exists {
+					cfg.Providers[name] = map[string]string{}
+				}
+			}
+			if name, ok := strings.CutPrefix(section, "env."); ok {
+				name = strings.TrimSuffix(name, ".secrets")
+				if _, exists := cfg.Envs[name]; !exists {
+					cfg.Envs[name] = nil
+					cfg.EnvNames = append(cfg.EnvNames, name)
+				}
+			}
+			continue
+		}
+
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			return nil, fmt.Errorf("line %d: expected key = value", i+1)
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+
+		switch {
+		case strings.HasPrefix(section, "providers."):
+			name := strings.TrimPrefix(section, "providers.")
+			cfg.Providers[name][key] = unquote(value)
+
+		case section == "secrets":
+			s, err := parseSecret(key, value)
+			if err != nil {
+				return nil, fmt.Errorf("line %d: %w", i+1, err)
+			}
+			cfg.Secrets = append(cfg.Secrets, s)
+
+		// [env.staging.secrets]
+		case strings.HasPrefix(section, "env.") && strings.HasSuffix(section, ".secrets"):
+			name := strings.TrimSuffix(strings.TrimPrefix(section, "env."), ".secrets")
+			s, err := parseSecret(key, value)
+			if err != nil {
+				return nil, fmt.Errorf("line %d: %w", i+1, err)
+			}
+			if _, seen := cfg.Envs[name]; !seen {
+				cfg.EnvNames = append(cfg.EnvNames, name)
+			}
+			cfg.Envs[name] = append(cfg.Envs[name], s)
+		}
+	}
+	return cfg, nil
+}
+
+// parseSecret reads either an inline table or a bare string.
+//
+//	NAME = { provider = "keychain", value = "NAME" }
+//	NAME = "literal"
+func parseSecret(name, value string) (Secret, error) {
+	s := Secret{Name: name}
+	if !strings.HasPrefix(value, "{") {
+		s.Value = unquote(value)
+		return s, nil
+	}
+	inner, ok := strings.CutSuffix(strings.TrimPrefix(value, "{"), "}")
+	if !ok {
+		return s, fmt.Errorf("unterminated inline table for %s", name)
+	}
+	for _, field := range splitFields(inner) {
+		k, v, ok := strings.Cut(field, "=")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(k) {
+		case "provider":
+			s.Provider = unquote(strings.TrimSpace(v))
+		case "value":
+			s.Value = unquote(strings.TrimSpace(v))
+		}
+	}
+	if s.Value == "" {
+		s.Value = name // fnox defaults the lookup key to the secret's name
+	}
+	return s, nil
+}
+
+// splitFields splits on commas that are not inside quotes.
+func splitFields(s string) []string {
+	var out []string
+	var cur strings.Builder
+	var quote byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+			cur.WriteByte(c)
+		case c == '"' || c == '\'':
+			quote = c
+			cur.WriteByte(c)
+		case c == ',':
+			out = append(out, cur.String())
+			cur.Reset()
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	if strings.TrimSpace(cur.String()) != "" {
+		out = append(out, cur.String())
+	}
+	return out
+}
+
+func unquote(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -1,0 +1,471 @@
+package secrets
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sample = `# A comment.
+[providers.keychain]
+type = "keychain"
+service = "fnox"
+
+[providers.shell]
+type = "env"
+
+[secrets]
+CLOUDFLARE_API_TOKEN  = { provider = "keychain", value = "CLOUDFLARE_API_TOKEN" }
+IRGO_IOS_TEAM         = { provider = "keychain", value = "IRGO_IOS_TEAM" }
+FROM_ENV              = { provider = "shell", value = "SOME_ENV_VAR" }
+DEFAULTED             = { provider = "keychain" }
+LITERAL               = "just-a-value"
+`
+
+func TestParse(t *testing.T) {
+	cfg, err := parse(sample)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.Providers["keychain"]["service"]; got != "fnox" {
+		t.Errorf("keychain service is %q", got)
+	}
+	if len(cfg.Secrets) != 5 {
+		t.Fatalf("parsed %d secrets, want 5", len(cfg.Secrets))
+	}
+
+	// Declaration order is preserved, so failures report predictably.
+	if cfg.Secrets[0].Name != "CLOUDFLARE_API_TOKEN" {
+		t.Errorf("first secret is %q", cfg.Secrets[0].Name)
+	}
+	// fnox lets you omit the lookup key; it defaults to the secret's name.
+	for _, s := range cfg.Secrets {
+		if s.Name == "DEFAULTED" && s.Value != "DEFAULTED" {
+			t.Errorf("DEFAULTED resolves against %q, want its own name", s.Value)
+		}
+	}
+}
+
+func TestResolveEnvAndLiteral(t *testing.T) {
+	cfg, err := parse(sample)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SOME_ENV_VAR", "from-the-environment")
+
+	for _, s := range cfg.Secrets {
+		switch s.Name {
+		case "FROM_ENV":
+			got, err := cfg.resolve(s)
+			if err != nil || got != "from-the-environment" {
+				t.Errorf("FROM_ENV = %q, %v", got, err)
+			}
+		case "LITERAL":
+			got, err := cfg.resolve(s)
+			if err != nil || got != "just-a-value" {
+				t.Errorf("LITERAL = %q, %v", got, err)
+			}
+		}
+	}
+}
+
+// TestUnknownProviderSaysWhatToDo — this reads a subset of what fnox writes,
+// so meeting a provider it does not implement has to point somewhere.
+func TestUnknownProviderSaysWhatToDo(t *testing.T) {
+	cfg, err := parse(`
+[providers.op]
+type = "onepassword"
+
+[secrets]
+TOKEN = { provider = "op", value = "op://vault/item/field" }
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = cfg.resolve(cfg.Secrets[0])
+	if err == nil {
+		t.Fatal("expected an error for an unimplemented provider")
+	}
+	if !contains(err.Error(), "fnox") {
+		t.Errorf("the error should point at fnox; it says %q", err)
+	}
+}
+
+// TestEnvironmentWins — CI supplies these names from repository secrets, and
+// anyone can export one for a single command. Neither should be overridden.
+func TestEnvironmentWins(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, ConfigName), `
+[secrets]
+ALREADY_SET = "from-the-file"
+`)
+	t.Setenv("ALREADY_SET", "from-the-environment")
+
+	applied, _, err := Apply(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range applied {
+		if name == "ALREADY_SET" {
+			t.Error("Apply overwrote a variable that was already set")
+		}
+	}
+	if os.Getenv("ALREADY_SET") != "from-the-environment" {
+		t.Error("the environment lost")
+	}
+}
+
+// TestNoConfigIsNotAnError — most projects have no secrets, and every command
+// has to work without a fnox.toml.
+func TestNoConfigIsNotAnError(t *testing.T) {
+	applied, skipped, err := Apply(t.TempDir(), "")
+	if err != nil {
+		t.Fatalf("a project with no fnox.toml should not error: %v", err)
+	}
+	if len(applied) != 0 || len(skipped) != 0 {
+		t.Errorf("applied %v, skipped %v", applied, skipped)
+	}
+}
+
+// TestFindWalksUp — commands run from a subdirectory (the docs site builds
+// from docs-templ) but credentials belong to the repository.
+func TestFindWalksUp(t *testing.T) {
+	root := t.TempDir()
+	write(t, filepath.Join(root, ConfigName), "[secrets]\n")
+	nested := filepath.Join(root, "docs", "deep")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := Find(nested)
+	if !ok {
+		t.Fatal("did not find the config from a subdirectory")
+	}
+	if filepath.Base(got) != ConfigName {
+		t.Errorf("found %q", got)
+	}
+}
+
+// TestApplyNeverReportsValues — the point of this package is that a secret
+// reaches the process without reaching a log. Apply returns names only.
+func TestApplyNeverReportsValues(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, ConfigName), `
+[secrets]
+SOME_TOKEN = "super-secret-value"
+`)
+	t.Setenv("SOME_TOKEN", "")
+	os.Unsetenv("SOME_TOKEN")
+
+	applied, skipped, err := Apply(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range applied {
+		if contains(name, "super-secret") {
+			t.Error("Apply returned a value, not a name")
+		}
+	}
+	for name, err := range skipped {
+		if contains(name+err.Error(), "super-secret") {
+			t.Error("a skip reason leaked the value")
+		}
+	}
+}
+
+func write(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) &&
+		(haystack == needle || len(needle) == 0 ||
+			indexOf(haystack, needle) >= 0)
+}
+
+func indexOf(h, n string) int {
+	for i := 0; i+len(n) <= len(h); i++ {
+		if h[i:i+len(n)] == n {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestSopsProvider decrypts a real SOPS file, if sops and a key are available.
+//
+// Skipped rather than mocked: the value of this provider is that it drives the
+// actual binary, and a fake exec would test the fake.
+func TestSopsProvider(t *testing.T) {
+	if _, err := exec.LookPath("sops"); err != nil {
+		t.Skip("sops is not on PATH")
+	}
+	keygen, err := exec.LookPath("age-keygen")
+	if err != nil {
+		t.Skip("age-keygen is not on PATH")
+	}
+
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "key.txt")
+	if out, err := exec.Command(keygen, "-o", keyFile).CombinedOutput(); err != nil {
+		t.Skipf("age-keygen failed: %s", out)
+	}
+	pub := agePublicKey(t, keyFile)
+
+	enc := filepath.Join(dir, "secrets.enc.yaml")
+	write(t, enc, "cloudflare:\n    api_token: the-token\n")
+	cmd := exec.Command("sops", "encrypt", "--age", pub, "--in-place", enc)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("sops encrypt: %s", out)
+	}
+
+	write(t, filepath.Join(dir, ConfigName), `
+[providers.sops]
+type = "sops"
+file = "secrets.enc.yaml"
+
+[secrets]
+CLOUDFLARE_API_TOKEN = { provider = "sops", value = "cloudflare.api_token" }
+`)
+
+	t.Setenv("SOPS_AGE_KEY_FILE", keyFile)
+	os.Unsetenv("CLOUDFLARE_API_TOKEN")
+
+	applied, skipped, err := Apply(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(applied) != 1 {
+		t.Fatalf("applied %v, skipped %v", applied, skipped)
+	}
+	if got := os.Getenv("CLOUDFLARE_API_TOKEN"); got != "the-token" {
+		t.Errorf("decrypted to %q", got)
+	}
+}
+
+func agePublicKey(t *testing.T, keyFile string) string {
+	t.Helper()
+	data, err := os.ReadFile(keyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if _, pub, ok := strings.Cut(line, "public key: "); ok {
+			return strings.TrimSpace(pub)
+		}
+	}
+	t.Fatal("no public key in the generated file")
+	return ""
+}
+
+// TestExtractPath — sops indexes with ["a"]["b"], and a dotted key is how a
+// fnox.toml would name it.
+func TestExtractPath(t *testing.T) {
+	if got := extractPath("cloudflare.api_token"); got != `["cloudflare"]["api_token"]` {
+		t.Errorf("extractPath = %s", got)
+	}
+	if got := extractPath("TOKEN"); got != `["TOKEN"]` {
+		t.Errorf("extractPath = %s", got)
+	}
+}
+
+// TestSopsKeyFromKeychainProvider is the arrangement worth recommending: one
+// age key held wherever secrets already live, everything else encrypted in the
+// repository. Here the key comes from another declared secret rather than from
+// a file on disk.
+func TestSopsKeyFromAnotherSecret(t *testing.T) {
+	if _, err := exec.LookPath("sops"); err != nil {
+		t.Skip("sops is not on PATH")
+	}
+	keygen, err := exec.LookPath("age-keygen")
+	if err != nil {
+		t.Skip("age-keygen is not on PATH")
+	}
+
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "key.txt")
+	if out, err := exec.Command(keygen, "-o", keyFile).CombinedOutput(); err != nil {
+		t.Skipf("age-keygen failed: %s", out)
+	}
+	pub := agePublicKey(t, keyFile)
+	priv := agePrivateKey(t, keyFile)
+
+	enc := filepath.Join(dir, "secrets.enc.yaml")
+	write(t, enc, "cloudflare:\n    api_token: composed\n")
+	if out, err := exec.Command("sops", "encrypt", "--age", pub,
+		"--in-place", enc).CombinedOutput(); err != nil {
+		t.Fatalf("sops encrypt: %s", out)
+	}
+
+	// The age key is declared like any other secret. In a real repository it
+	// would be `provider = "keychain"`; here it comes from the environment so
+	// the test touches no keychain.
+	write(t, filepath.Join(dir, ConfigName), `
+[providers.shell]
+type = "env"
+
+[providers.sops]
+type = "sops"
+file = "secrets.enc.yaml"
+age_key = "SOPS_AGE_KEY"
+
+[secrets]
+CLOUDFLARE_API_TOKEN = { provider = "sops", value = "cloudflare.api_token" }
+SOPS_AGE_KEY = { provider = "shell", value = "TEST_AGE_KEY" }
+`)
+	t.Setenv("TEST_AGE_KEY", priv)
+	os.Unsetenv("SOPS_AGE_KEY")
+	os.Unsetenv("CLOUDFLARE_API_TOKEN")
+	os.Unsetenv("SOPS_AGE_KEY_FILE")
+
+	// Declared first, so this also proves the order does not matter: the sops
+	// secret is resolved before the key it needs.
+	applied, skipped, err := Apply(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.Getenv("CLOUDFLARE_API_TOKEN") != "composed" {
+		t.Errorf("applied %v, skipped %v", applied, skipped)
+	}
+}
+
+// TestSopsKeyCannotLiveInTheFileItUnlocks — a cycle that would otherwise
+// recurse until the stack ran out.
+func TestSopsKeyCannotLiveInTheFileItUnlocks(t *testing.T) {
+	cfg, err := parse(`
+[providers.sops]
+type = "sops"
+file = "secrets.enc.yaml"
+age_key = "SOPS_AGE_KEY"
+
+[secrets]
+SOPS_AGE_KEY = { provider = "sops", value = "age.key" }
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("SOPS_AGE_KEY")
+	if _, err := cfg.resolveNamed("SOPS_AGE_KEY"); err == nil {
+		t.Fatal("expected a refusal, not a cycle")
+	}
+}
+
+func agePrivateKey(t *testing.T, keyFile string) string {
+	t.Helper()
+	data, err := os.ReadFile(keyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "AGE-SECRET-KEY-") {
+			return strings.TrimSpace(line)
+		}
+	}
+	t.Fatal("no private key in the generated file")
+	return ""
+}
+
+// TestUsesOnlyReportsDeclaredProviders — the CLI installs a tool when the
+// config asks for it, so a keychain-only project must not report sops.
+func TestUsesOnlyReportsDeclaredProviders(t *testing.T) {
+	cfg, err := parse(`
+[providers.keychain]
+type = "keychain"
+
+[secrets]
+TOKEN = { provider = "keychain", value = "TOKEN" }
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Uses("sops") {
+		t.Error("a keychain-only project should not pull in sops")
+	}
+	if !cfg.Uses("keychain") {
+		t.Error("it does use keychain")
+	}
+}
+
+// Environments are the same names against different backing services. The
+// overlay has to be a genuine overlay: a name declared once at the top has to
+// keep working in every environment, or every environment ends up restating
+// the whole file and they drift.
+func TestEnvironmentOverlay(t *testing.T) {
+	cfg, err := parse(`
+[providers.demo]
+type = "literal"
+
+[secrets]
+SHARED   = { provider = "demo", value = "same-everywhere" }
+DATABASE = { provider = "demo", value = "prod-db" }
+
+[env.staging.secrets]
+DATABASE     = { provider = "demo", value = "staging-db" }
+STAGING_ONLY = { provider = "demo", value = "extra" }
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := cfg.EnvNames; len(got) != 1 || got[0] != "staging" {
+		t.Fatalf("EnvNames = %v, want [staging]", got)
+	}
+	if !cfg.HasEnv("staging") || cfg.HasEnv("production") {
+		t.Error("HasEnv does not match what is declared")
+	}
+
+	base := valuesOf(cfg)
+	if base["DATABASE"] != "prod-db" {
+		t.Errorf("base DATABASE = %q, want prod-db", base["DATABASE"])
+	}
+	if _, ok := base["STAGING_ONLY"]; ok {
+		t.Error("base config carries a staging-only secret")
+	}
+
+	staging := valuesOf(cfg.For("staging"))
+	if staging["DATABASE"] != "staging-db" {
+		t.Errorf("staging DATABASE = %q, want staging-db — the overlay did not win",
+			staging["DATABASE"])
+	}
+	if staging["SHARED"] != "same-everywhere" {
+		t.Errorf("staging SHARED = %q — a name declared once must survive the overlay",
+			staging["SHARED"])
+	}
+	if staging["STAGING_ONLY"] != "extra" {
+		t.Error("a secret only one environment declares was dropped")
+	}
+
+	// The base config must not be mutated by asking for an environment: the
+	// same *Config is reused across commands in one process.
+	if again := valuesOf(cfg); again["DATABASE"] != "prod-db" {
+		t.Errorf("For() mutated the base config: DATABASE = %q", again["DATABASE"])
+	}
+}
+
+// An unknown environment has to be an error. Silently falling back to the
+// defaults means a typo in --env pushes production values to staging.
+func TestUnknownEnvironmentIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, ConfigName), `
+[providers.demo]
+type = "literal"
+
+[secrets]
+A = { provider = "demo", value = "1" }
+`)
+	if _, _, err := Apply(dir, "nope"); err == nil {
+		t.Fatal("Apply accepted an environment the file does not declare")
+	}
+}
+
+func valuesOf(cfg *Config) map[string]string {
+	out := map[string]string{}
+	for _, s := range cfg.Secrets {
+		out[s.Name] = s.Value
+	}
+	return out
+}


### PR DESCRIPTION
> **Stacked on #17 and #18.** Until those merge, this PR's diff includes them. Review the top commit.

Deploying needed `CLOUDFLARE_API_TOKEN` in three places — the keychain, GitHub Actions, and the Worker — and only the first was automated. The others were `gh secret set` and `wrangler secret put` typed from memory, with nothing to say when they had drifted.

```
irgo secrets list     what this project needs, and what is missing
irgo secrets status   whether each destination actually has it
irgo secrets push     copy it where it is also needed
```

Values are never printed and never passed as arguments; both destinations read stdin, so a secret never reaches shell history or the process list. Only what a destination should hold is sent: a Worker gets the app's own secrets, while the token that can redeploy it — and signing keys it could never use — stay in CI.

### The part underneath

Every setting is now declared once. It had been declared **four** times: a struct field, a case in the parser, a registry literal, and a case in the reader — with nothing linking them. A setting added to three and missed in the fourth resolved to empty with no compile error. `android.key_alias`, `keystore_pass`, `key_pass`, `windows.cert_pass` and `macos.team` were all parseable and unreadable exactly that way.

### Two real bugs this surfaced

- **`irgo.package.toml` is committed, and the wizard wrote every answer into it** — including the app-specific password it had just said was going somewhere gitignored. Secrets now route to the gitignored overlay, created `0600`, and are not echoed back.
- **`android.keystore` names a file and was not marked secret**, so it classified as the app's own runtime value and `push cloudflare` would have base64'd the Android signing key into the Worker. That key cannot be reissued.

### Validation

Settings carry what a valid value looks like, checked before a build and before a push. That immediately caught irgo deriving `com.irgo.irgo-demo` as a Play package — hyphens are legal in an Apple bundle ID and illegal in an Android package name, and one function served both.

### Environments

Declared as `[env.staging.secrets]`, overlaying rather than replacing, so a name declared once keeps working everywhere. They map onto what each destination already has: a GitHub environment, wrangler's `--env`.

---

Third of five pieces splitting up #10. 19 files.