### PR TITLE
fix(new): say why the first command in a new project fails

### DIFF
--- a/cmd/irgo/cmd_project_new.go
+++ b/cmd/irgo/cmd_project_new.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"embed"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -229,6 +231,36 @@ func isRemoteModulePath(path string) bool {
 	return false
 }
 
+// explainTidyFailure turns one particular go error into something a person can
+// act on.
+//
+// A scaffolded project pins the CLI's own version. When that version has not
+// been tagged yet, every new project fails its first command with:
+//
+//	github.com/stukennedy/irgo@v0.4.0: reading .../go.mod at revision v0.4.0:
+//	unknown revision v0.4.0
+//
+// which reads as a broken template rather than an unpublished release, and is
+// followed a moment later by "Project created successfully!". The remedy
+// already exists — `irgo project pin` — so the only thing missing was saying
+// so at the moment it fails.
+func explainTidyFailure(stderr string) {
+	if !strings.Contains(stderr, "unknown revision") ||
+		!strings.Contains(stderr, irgoModulePath) {
+		return
+	}
+	fmt.Println()
+	fmt.Printf("This project pins %s at a version that is not published yet.\n", irgoModulePath)
+	fmt.Println("Nothing is wrong with the project; the version simply cannot be fetched.")
+	fmt.Println()
+	fmt.Println("Point it somewhere that resolves:")
+	fmt.Println("  go tool irgo project pin release        # the latest published version")
+	fmt.Println("  go tool irgo project pin local ../irgo  # a checkout you are editing")
+}
+
+// irgoModulePath is the module a scaffolded project depends on.
+const irgoModulePath = "github.com/stukennedy/irgo"
+
 func newProject(name string) error {
 	// Determine project directory, project name, and module path
 	var projectDir string
@@ -447,9 +479,11 @@ func newProject(name string) error {
 		fmt.Println("Running go mod tidy...")
 		tidyCmd := exec.Command(goBin(), "mod", "tidy")
 		tidyCmd.Dir = projectDir
+		var tidyErr bytes.Buffer
 		tidyCmd.Stdout = os.Stdout
-		tidyCmd.Stderr = os.Stderr
+		tidyCmd.Stderr = io.MultiWriter(os.Stderr, &tidyErr)
 		if err := tidyCmd.Run(); err != nil {
+			explainTidyFailure(tidyErr.String())
 			fmt.Printf("Warning: go mod tidy failed: %v\n", err)
 		}
 	}

--- a/cmd/irgo/cmd_project_new_test.go
+++ b/cmd/irgo/cmd_project_new_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestSanitizeIdentifier(t *testing.T) {
 	cases := map[string]string{
@@ -16,6 +19,35 @@ func TestSanitizeIdentifier(t *testing.T) {
 	for in, want := range cases {
 		if got := sanitizeIdentifier(in); got != want {
 			t.Errorf("sanitizeIdentifier(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestUnpublishedPinIsExplained — the failure a new user meets first.
+//
+// A scaffolded project pins the CLI's own version, and when that has not been
+// tagged, `go mod tidy` fails with "unknown revision". That reads as a broken
+// template rather than an unpublished release, and irgo then says "Project
+// created successfully!" a moment later.
+func TestUnpublishedPinIsExplained(t *testing.T) {
+	real := "go: downloading...\ngithub.com/stukennedy/irgo@v0.4.0: reading " +
+		"github.com/stukennedy/irgo/go.mod at revision v0.4.0: unknown revision v0.4.0\n"
+
+	if out := captureStdout(t, func() { explainTidyFailure(real) }); out == "" {
+		t.Error("the unpublished-pin failure produced no explanation")
+	} else if !strings.Contains(out, "project pin") {
+		t.Errorf("explanation does not name the remedy:\n%s", out)
+	}
+
+	// Anything else must stay quiet: a message that appears for unrelated
+	// failures teaches people to skip it.
+	for _, other := range []string{
+		"go: updates to go.mod needed\n",
+		"github.com/other/thing@v1.0.0: unknown revision v1.0.0\n",
+		"",
+	} {
+		if out := captureStdout(t, func() { explainTidyFailure(other) }); out != "" {
+			t.Errorf("explained an unrelated failure %q:\n%s", other, out)
 		}
 	}
 }


### PR DESCRIPTION
Addresses #23.

A scaffolded project pins the CLI's own version. When that version has not been tagged, the first thing anyone runs fails:

```
$ irgo project new myapp
...
Running go mod tidy...
github.com/stukennedy/irgo@v0.4.0: reading github.com/stukennedy/irgo/go.mod
at revision v0.4.0: unknown revision v0.4.0
Warning: go mod tidy failed: exit status 1

Project created successfully!
```

Two problems there. The error reads as a broken template rather than an unpublished release, and "Project created successfully!" a line later suggests it can be ignored — it cannot; nothing in the project builds.

### The change

`irgo project pin` already fixes this. The only thing missing was saying so at the moment it fails:

```
This project pins github.com/stukennedy/irgo at a version that is not published yet.
Nothing is wrong with the project; the version simply cannot be fetched.

Point it somewhere that resolves:
  go tool irgo project pin release        # the latest published version
  go tool irgo project pin local ../irgo  # a checkout you are editing
```

### What I deliberately did not do

A test asserting the template's pinned version is published would fail until someone tags a release. A pull request cannot do that, and a red check nobody can turn green is one people learn to ignore.

Tagging `v0.4.0` is still the actual fix for #23 — this only makes the failure legible while the pin is ahead of the tags, and harmless afterwards.

The message is narrow on purpose: it triggers only on `unknown revision` for the irgo module. A message that shows up for unrelated failures teaches people to skip it, so the test covers that too.

Independent of #17–#21 and #25.