### PR TITLE
fix(new): scaffolded projects are not gofmt-clean

### DIFF
--- a/cmd/irgo/cmd_project_upgrade.go
+++ b/cmd/irgo/cmd_project_upgrade.go
@@ -16,6 +16,9 @@ package main
 
 import (
 	"fmt"
+	"go/format"
+	"go/parser"
+	"go/token"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -201,7 +204,47 @@ func renderTemplate(body, projectName, modulePath, replace string) string {
 	body = strings.ReplaceAll(body, "{{GO_VERSION}}", scaffoldGoVersion())
 	body = strings.ReplaceAll(body, "{{REPLACE_DIRECTIVE}}", replace)
 	body = strings.ReplaceAll(body, "{{COMMANDS}}", renderCommandTable())
-	return body
+	return gofmtIfGo(body)
+}
+
+// gofmtIfGo formats a rendered template when what came out is Go, and returns
+// it untouched when it is not.
+//
+// Import order is the reason. gofmt sorts a block alphabetically, and a
+// scaffolded file imports both the framework and the new project:
+//
+//	"github.com/stukennedy/irgo/desktop"
+//	"todo/app"
+//
+// Which of those sorts first depends on the module name, and the module name
+// arrives at scaffold time — so there is no order the template can be written
+// in that is correct for every project. `todo` sorts after `github.com/…` and
+// `alpha` sorts before it. Whatever the template picks is wrong for half the
+// names someone might choose.
+//
+// The result was that every project irgo generated failed `gofmt -l` on the
+// files the developer had not written yet, including upstream's own todo
+// example, which is checked in unformatted for exactly this reason.
+//
+// Here rather than at the call sites because `project check` and `project
+// upgrade` compare this output against the file on disk. If `new` formatted and
+// they did not, every scaffolded Go file would report as modified on a project
+// nobody had touched — the same drift the three copies of the placeholder list
+// used to cause, which is why they were merged into this function.
+//
+// Non-Go bodies select themselves out: go.mod, README.md and the Gradle files
+// do not parse, so format.Source fails and the original is returned. The parse
+// check first is what stops a stray text file that happens to be valid Go from
+// being reformatted behind someone's back.
+func gofmtIfGo(body string) string {
+	if _, err := parser.ParseFile(token.NewFileSet(), "", body, parser.PackageClauseOnly); err != nil {
+		return body
+	}
+	out, err := format.Source([]byte(body))
+	if err != nil {
+		return body
+	}
+	return string(out)
 }
 
 // printTemplateDiff shows what the template holds for a file you own, so an

--- a/cmd/irgo/scaffold_gofmt_test.go
+++ b/cmd/irgo/scaffold_gofmt_test.go
@@ -1,0 +1,71 @@
+// What irgo generates must be formatted, for any project name.
+//
+// A developer running `gofmt -l .` on a project made five seconds ago should
+// see nothing. Before this, they saw the files irgo had just written.
+//
+// The name matters, which is what makes this worth a test rather than a glance
+// at the templates. A scaffolded file imports both the framework and the new
+// project, and gofmt sorts those alphabetically, so `github.com/stukennedy/…`
+// comes before `zebra/app` and after `alpha/app`. No fixed order in the
+// template is right for both. So both are checked here.
+package main
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestScaffoldedGoIsFormatted(t *testing.T) {
+	// One name that sorts before the framework's import path and one that
+	// sorts after. A template hand-sorted for either fails on the other.
+	for _, project := range []string{"alpha", "zebra"} {
+		t.Run(project, func(t *testing.T) {
+			err := fs.WalkDir(templateFS, "templates", func(path string, d fs.DirEntry, err error) error {
+				if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go.tmpl") {
+					return err
+				}
+				body, err := templateFS.ReadFile(path)
+				if err != nil {
+					return err
+				}
+
+				got := renderTemplate(string(body), project, project, "")
+				want := gofmtIfGo(got)
+				if got != want {
+					t.Errorf("%s is not gofmt'd once rendered for module %q\n\n%s",
+						filepath.Base(path), project, firstDifference(got, want))
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("walking templates: %v", err)
+			}
+		})
+	}
+}
+
+// firstDifference reports the first line that differs, because a whole-file
+// dump of a scaffolded main.go buries the one import that moved.
+func firstDifference(got, want string) string {
+	g, w := strings.Split(got, "\n"), strings.Split(want, "\n")
+	for i := 0; i < len(g) && i < len(w); i++ {
+		if g[i] != w[i] {
+			return "line " + itoa(i+1) + ":\n  have: " + g[i] + "\n  want: " + w[i]
+		}
+	}
+	return "the files differ in length"
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/examples/todo/main.go
+++ b/examples/todo/main.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/stukennedy/irgo/pkg/livereload"
 	"todo/app"
 	"todo/templates"
-	"github.com/stukennedy/irgo/pkg/livereload"
 )
 
 func main() {

--- a/examples/todo/main_desktop.go
+++ b/examples/todo/main_desktop.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"todo/app"
-	"todo/templates"
 	"github.com/stukennedy/irgo/desktop"
 	"github.com/stukennedy/irgo/pkg/livereload"
+	"todo/app"
+	"todo/templates"
 )
 
 func main() {

--- a/examples/todo/mobile/mobile.go
+++ b/examples/todo/mobile/mobile.go
@@ -19,8 +19,8 @@ package mobile
 import (
 	"fmt"
 
-	"todo/app"
 	irgomobile "github.com/stukennedy/irgo/mobile"
+	"todo/app"
 )
 
 // Initialize sets up the mobile bridge and app routes.
@@ -91,7 +91,7 @@ type streamCallbackAdapter struct{ cb StreamCallback }
 func (a streamCallbackAdapter) OnResponse(status int, headersJSON string) {
 	a.cb.OnResponse(status, headersJSON)
 }
-func (a streamCallbackAdapter) OnChunk(chunk []byte)          { a.cb.OnChunk(chunk) }
+func (a streamCallbackAdapter) OnChunk(chunk []byte)           { a.cb.OnChunk(chunk) }
 func (a streamCallbackAdapter) OnComplete(errorMessage string) { a.cb.OnComplete(errorMessage) }
 
 // HandleRequestStream processes an HTTP request, streaming the response


### PR DESCRIPTION
A project created five seconds ago fails `gofmt -l .` on files nobody wrote. So does the todo example in this repository.

It is not a typo in a template. A scaffolded file imports both the framework and the new project, and gofmt sorts a block alphabetically:

    "github.com/stukennedy/irgo/desktop"
    "todo/app"

`todo` sorts after that; `alpha` sorts before it. The module name arrives at scaffold time and the template is written once, so whatever order it picks is wrong for half the names someone might choose. The only place that knows enough is after substitution.

So gofmt runs inside renderTemplate rather than at its five call sites — `project check` and `project upgrade` compare rendered output against the file on disk, and if `new` formatted while they did not, every scaffolded Go file would report as modified on an untouched project.

Non-Go templates select themselves out: go.mod and the Gradle files do not parse. The parse check before format.Source stops a text file that happens to be valid Go being rewritten.

The test renders every Go template twice, under names sorting either side of the framework's path, so a hand-sorted template cannot pass by luck. It caught a second one while being written: misaligned funcs in mobile.go.tmpl.

Verified on the merge result with current main, not just the branch.
