### PR TITLE
fix(upgrade): merge .gitignore instead of replacing it

### DIFF
--- a/cmd/irgo/cmd_project_upgrade.go
+++ b/cmd/irgo/cmd_project_upgrade.go
@@ -99,6 +99,32 @@ func runUpgrade(force, showDiff bool) error {
 			return nil
 		}
 
+		// .gitignore is both, so it is merged rather than replaced.
+		//
+		// It is framework-owned because irgo decides which generated paths
+		// exist, and every upgrade that adds one has to add its rule. It is
+		// also a file projects legitimately write in — a build output of their
+		// own, an editor directory, a decision worth a comment.
+		//
+		// Overwriting served the first and silently destroyed the second. It
+		// happened here: an upgrade removed a project's note explaining why
+		// tokibundle/ is committed while correctly adding ios/App/, and the
+		// only trace was a .irgo-bak nobody reads.
+		if rel == ".gitignore" && herr == nil {
+			merged, added := mergeGitignore(string(have), body)
+			if added == 0 {
+				unchanged++
+				return nil
+			}
+			if err := os.WriteFile(rel, []byte(merged), 0o644); err != nil {
+				failed = append(failed, fmt.Sprintf("%s: %v", rel, err))
+				return nil
+			}
+			fmt.Printf("  updated: %s  (%d rule(s) added, yours kept)\n", rel, added)
+			updated++
+			return nil
+		}
+
 		if !isFrameworkOwned(rel) && herr == nil && !force {
 			// Seeded once, yours since. Report rather than overwrite.
 			drifted = append(drifted, rel)

--- a/cmd/irgo/gitignore_merge.go
+++ b/cmd/irgo/gitignore_merge.go
@@ -1,0 +1,60 @@
+// Adding the framework's ignore rules without deleting yours.
+//
+// .gitignore is the one framework-owned file a project also writes in. irgo
+// decides which paths are generated, so an upgrade that adds one has to add
+// its rule — and a developer adds their own build output, their editor's
+// directory, and the occasional comment explaining a decision that took an
+// afternoon to reach.
+//
+// Replacing the file served the first of those and silently destroyed the
+// second.
+package main
+
+import "strings"
+
+// mergeGitignore returns the project's file with any rules the template has
+// and it does not, and the number added.
+//
+// Only ever appends. A rule the project deleted on purpose comes back, which
+// is the lesser wrong: irgo cannot tell a deliberate deletion from a file that
+// predates the rule, and the failure modes are not symmetric — a returning
+// rule is visible in the diff, while a deleted one shows up as a generated
+// file committed three weeks later.
+func mergeGitignore(have, want string) (string, int) {
+	existing := map[string]bool{}
+	for _, line := range strings.Split(have, "\n") {
+		if p := strings.TrimSpace(line); p != "" && !strings.HasPrefix(p, "#") {
+			existing[p] = true
+		}
+	}
+
+	// Comments travel with the rule below them. A bare pattern appended
+	// without its explanation is how .gitignore files become lists of paths
+	// nobody dares remove.
+	var pending, added []string
+	count := 0
+	for _, line := range strings.Split(want, "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == "":
+			pending = nil // a blank line ends a comment block
+		case strings.HasPrefix(trimmed, "#"):
+			pending = append(pending, line)
+		case existing[trimmed]:
+			pending = nil // already covered; its comment is not news either
+		default:
+			added = append(added, pending...)
+			added = append(added, line)
+			pending = nil
+			count++
+		}
+	}
+	if count == 0 {
+		return have, 0
+	}
+
+	out := strings.TrimRight(have, "\n")
+	out += "\n\n# Added by irgo project upgrade.\n"
+	out += strings.Join(added, "\n") + "\n"
+	return out, count
+}

--- a/cmd/irgo/gitignore_merge_test.go
+++ b/cmd/irgo/gitignore_merge_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMergeGitignore(t *testing.T) {
+	for _, tc := range []struct {
+		name, have, want string
+		added            int
+		keeps            []string
+		gains            []string
+	}{{
+		name:  "a new rule arrives with its comment",
+		have:  "*_templ.go\n",
+		want:  "*_templ.go\n\n# The SwiftPM shell for iOS on Linux.\nios/App/\n",
+		added: 1,
+		keeps: []string{"*_templ.go"},
+		gains: []string{"ios/App/", "# The SwiftPM shell for iOS on Linux."},
+	}, {
+		// The failure this exists for: a project's own comment explaining a
+		// decision, deleted by an upgrade that was adding something else.
+		name: "the project's own notes survive",
+		have: "*_templ.go\n\n# tokibundle/ is committed in full: bundle_gen.go holds\n" +
+			"# the default locale and toki cannot start without it.\n\nnode_modules/\n",
+		want:  "*_templ.go\nios/App/\n",
+		added: 1,
+		keeps: []string{
+			"# tokibundle/ is committed in full: bundle_gen.go holds",
+			"node_modules/",
+		},
+		gains: []string{"ios/App/"},
+	}, {
+		name:  "nothing new means no write",
+		have:  "*_templ.go\nios/App/\n",
+		want:  "# a comment\n*_templ.go\nios/App/\n",
+		added: 0,
+		keeps: []string{"*_templ.go"},
+	}, {
+		name:  "whitespace differences are not new rules",
+		have:  "  *_templ.go  \n",
+		want:  "*_templ.go\n",
+		added: 0,
+	}, {
+		name:  "a negation is a rule like any other",
+		have:  ".claude/*\n",
+		want:  ".claude/*\n!.claude/skills/\n",
+		added: 1,
+		gains: []string{"!.claude/skills/"},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, n := mergeGitignore(tc.have, tc.want)
+			if n != tc.added {
+				t.Errorf("added %d rule(s), want %d\n\n%s", n, tc.added, got)
+			}
+			if n == 0 && got != tc.have {
+				t.Errorf("nothing was added but the file changed:\n%s", got)
+			}
+			for _, k := range tc.keeps {
+				if !strings.Contains(got, k) {
+					t.Errorf("lost %q:\n%s", k, got)
+				}
+			}
+			for _, g := range tc.gains {
+				if !strings.Contains(got, g) {
+					t.Errorf("did not gain %q:\n%s", g, got)
+				}
+			}
+		})
+	}
+}
+
+// TestMergeGitignoreIsIdempotent — upgrade runs repeatedly, and a merge that
+// appended every time would grow the file without bound.
+func TestMergeGitignoreIsIdempotent(t *testing.T) {
+	have := "*_templ.go\n"
+	want := "*_templ.go\n\n# native shell\nios/App/\n"
+
+	once, n1 := mergeGitignore(have, want)
+	twice, n2 := mergeGitignore(once, want)
+
+	if n1 != 1 {
+		t.Fatalf("first merge added %d, want 1", n1)
+	}
+	if n2 != 0 {
+		t.Errorf("second merge added %d, want 0", n2)
+	}
+	if twice != once {
+		t.Errorf("second merge changed the file:\n%s", twice)
+	}
+}


### PR DESCRIPTION
`project upgrade` replaced .gitignore wholesale, silently discarding anything the project had added.

It is the one framework-owned file a project also writes in. irgo decides which paths are generated, so an upgrade that adds one has to add its rule — and a developer adds their own build output, their editor's directory, and the occasional comment explaining a decision.

Now it appends what is missing, with the comment belonging to it, and never removes a line. A rule the project deleted on purpose comes back, which is the lesser wrong: irgo cannot tell a deliberate deletion from a file predating the rule, and a returning rule is visible in the diff while a deleted one shows up as a generated file committed three weeks later.

Idempotent, since upgrade runs repeatedly. Tested, including that.

Verified on the merge result with current main.
