### PR TITLE
feat(assets): let Tailwind see components from a dependency

### DIFF
--- a/cmd/irgo/cmd_tools.go
+++ b/cmd/irgo/cmd_tools.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 )
 
@@ -139,7 +140,108 @@ func runCSS() error {
 		return err
 	}
 	fmt.Println("Building CSS...")
-	return runCommand(bin, "-i", in, "-o", out, "--minify")
+
+	// Components can come from a dependency, and Tailwind only scans the
+	// project. Without this they render with classes no stylesheet defines —
+	// the markup is right and the page is unstyled, which looks like a broken
+	// component rather than a missing scan path.
+	entry, cleanup, err := cssEntryWithDependencySources(in)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return runCommand(bin, "-i", entry, "-o", out, "--minify")
+}
+
+// cssEntryWithDependencySources returns a Tailwind entry point that also scans
+// any dependency the project imports templ components from.
+//
+// Scoped to the packages actually imported, not the whole module. That is the
+// difference between a stylesheet carrying what this project uses and one
+// carrying every component a library ships:
+//
+//	no scanning          14 KB
+//	one imported package 15 KB
+//	the whole module    250 KB
+//
+// The generated entry is a temporary file rather than an edit to input.css:
+// that file belongs to the project, and paths resolved from a module cache are
+// machine- and version-specific — committing them would break on the next
+// machine and on every upgrade.
+func cssEntryWithDependencySources(in string) (path string, cleanup func(), err error) {
+	noop := func() {}
+
+	dirs, err := templComponentDirs()
+	if err != nil || len(dirs) == 0 {
+		return in, noop, nil // nothing outside the project; use it as-is
+	}
+
+	original, err := os.ReadFile(in)
+	if err != nil {
+		return "", noop, err
+	}
+	return writeCSSEntry(in, original, dirs)
+}
+
+// writeCSSEntry writes the scan paths ahead of the project's own stylesheet.
+//
+// A temporary file rather than an edit to input.css: that file belongs to the
+// project, and a module cache path carries both the machine and the exact
+// version — committing one would break on the next machine and on every
+// upgrade.
+func writeCSSEntry(in string, original []byte, dirs []string) (string, func(), error) {
+	noop := func() {}
+
+	var b strings.Builder
+	for _, d := range dirs {
+		fmt.Fprintf(&b, "@source %q;\n", d)
+	}
+	b.Write(original)
+
+	// Beside input.css, so the relative @import paths inside it still resolve.
+	f, err := os.CreateTemp(filepath.Dir(in), ".irgo-tailwind-*.css")
+	if err != nil {
+		return "", noop, err
+	}
+	name := f.Name()
+	if _, err := f.WriteString(b.String()); err != nil {
+		f.Close()
+		os.Remove(name)
+		return "", noop, err
+	}
+	f.Close()
+	return name, func() { os.Remove(name) }, nil
+}
+
+// templComponentDirs lists the directories of imported packages that live
+// outside this module and ship .templ files.
+//
+// `go list` answers both questions at once: it resolves an import path to the
+// directory the module cache put it in, which is the path Tailwind needs and
+// the one nobody can write down by hand.
+func templComponentDirs() ([]string, error) {
+	// Output is used even when the command fails. `go list` reports what it
+	// resolved and exits non-zero for anything it could not — a project mid-
+	// edit, or one package with a missing go.sum entry. Discarding the whole
+	// answer over one bad package silently drops the styles for every good
+	// one, and the page renders unstyled with nothing to explain why.
+	cmd := exec.Command(goBin(), "list", "-deps", "-f",
+		"{{if and .Module (not .Module.Main)}}{{.Dir}}{{end}}", "./...")
+	out, _ := cmd.Output()
+	seen := map[string]bool{}
+	var dirs []string
+	for _, dir := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if dir == "" || seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		if templs, _ := filepath.Glob(filepath.Join(dir, "*.templ")); len(templs) > 0 {
+			dirs = append(dirs, dir)
+		}
+	}
+	sort.Strings(dirs)
+	return dirs, nil
 }
 
 // ensureAssets regenerates everything that is gitignored yet embedded into a

--- a/cmd/irgo/cmd_tools_css_test.go
+++ b/cmd/irgo/cmd_tools_css_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Components can live in a dependency, and Tailwind only scans the project.
+// Without the generated @source lines they render with classes no stylesheet
+// defines: the markup is correct and the page is unstyled, which reads as a
+// broken component rather than a missing scan path.
+
+// TestNoDependencyComponentsUsesInputDirectly — a project with nothing to add
+// must build from its own input.css, not a copy of it. A temporary file that
+// exists for every project is a temporary file that will eventually be left
+// behind.
+func TestNoDependencyComponentsUsesInputDirectly(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "input.css")
+	if err := os.WriteFile(in, []byte("@import \"tailwindcss\";\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	inProjectDir(t, dir)
+
+	entry, cleanup, err := cssEntryWithDependencySources(in)
+	defer cleanup()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry != in {
+		t.Errorf("entry = %q, want the project's own %q", entry, in)
+	}
+}
+
+// TestGeneratedEntryKeepsTheProjectsOwnCSS — the project's stylesheet has to
+// survive intact, and the @source lines have to precede it.
+func TestGeneratedEntryKeepsTheProjectsOwnCSS(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "input.css")
+	const own = "@import \"tailwindcss\";\n.mine { color: red }\n"
+	if err := os.WriteFile(in, []byte(own), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Exercise the writer directly: resolving real dependencies needs a real
+	// module, and what matters here is that nothing of the project is lost.
+	entry, cleanup, err := writeCSSEntry(in, []byte(own), []string{"/pkg/mod/example/button"})
+	defer cleanup()
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(body)
+
+	if !strings.Contains(got, own) {
+		t.Error("the project's own CSS did not survive into the generated entry")
+	}
+	if !strings.Contains(got, `@source "/pkg/mod/example/button";`) {
+		t.Errorf("no @source for the dependency:\n%s", got)
+	}
+	if strings.Index(got, "@source") > strings.Index(got, ".mine") {
+		t.Error("@source must come before the project's rules")
+	}
+	// Beside input.css, or the relative @import paths inside it stop resolving.
+	if filepath.Dir(entry) != filepath.Dir(in) {
+		t.Errorf("entry at %s, not beside %s", entry, in)
+	}
+}
+
+// TestGeneratedEntryIsRemoved — it carries machine-specific module cache paths
+// and must never be left in a project, let alone committed.
+func TestGeneratedEntryIsRemoved(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "input.css")
+	if err := os.WriteFile(in, []byte("@import \"tailwindcss\";\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entry, cleanup, err := writeCSSEntry(in, []byte("x"), []string{"/pkg/mod/example/button"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanup()
+	if _, err := os.Stat(entry); !os.IsNotExist(err) {
+		t.Errorf("%s survived cleanup", entry)
+	}
+}
+
+// TestProjectCSSIsNeverEdited — input.css belongs to the project. Writing a
+// module cache path into it would break on the next machine and on every
+// version bump.
+func TestProjectCSSIsNeverEdited(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "input.css")
+	const own = "@import \"tailwindcss\";\n"
+	if err := os.WriteFile(in, []byte(own), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, cleanup, err := writeCSSEntry(in, []byte(own), []string{"/pkg/mod/example/button"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanup()
+	after, err := os.ReadFile(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != own {
+		t.Errorf("input.css was modified:\n%s", after)
+	}
+}
+
+func inProjectDir(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(prev) })
+}


### PR DESCRIPTION
Tailwind scans the project's own files for class names. Components arriving from a module are not among them, so their classes are stripped from the generated stylesheet and the component renders unstyled — with nothing in the build to say why.

Verified on the merge result with current main.
