### PR TITLE
fix(mobile): keep the x/mobile clone out of a directory the OS sweeps

### DIFF
--- a/cmd/irgo/cmd_app_build.go
+++ b/cmd/irgo/cmd_app_build.go
@@ -144,9 +144,27 @@ func ensureGobindTool() error {
 	return nil
 }
 
+// mobileCloneDir is where the private x/mobile checkout lives.
+//
+// It used to be $TMPDIR/golang-mobile, which macOS sweeps. Once that happens
+// the generated go.work names a directory that is gone, and every `go` command
+// in the project fails — including `go tool irgo` and `go run ./cmd/irgo`, so
+// irgo cannot repair the file it wrote. The only way out is deleting go.work
+// by hand, which the error does not suggest.
+//
+// ~/.irgo is not swept, and irgo already owns it. The directory keeps its old
+// name so a go.work written by an earlier version is still recognised as
+// irgo's work.
+func mobileCloneDir() string { return filepath.Join(homeDir(), ".irgo", "golang-mobile") }
+
+// legacyMobileCloneDir is the old location, still recognised so a workspace
+// written before this change is identified as irgo-generated and cleaned up
+// rather than left for someone to puzzle over.
+func legacyMobileCloneDir() string { return filepath.Join(os.TempDir(), "golang-mobile") }
+
 func ensureMobileBuildSetup() error {
-	// An existing go.work can be stale: it references the temp x/mobile clone
-	// (os.TempDir()/golang-mobile) that macOS may clean up between sessions. A
+	// An existing go.work can be stale: it references the x/mobile clone, which
+	// older versions put in $TMPDIR where macOS sweeps it. A
 	// stale go.work breaks every `go` command with "use ...: directory does not
 	// exist", and irgo previously never validated it — users had to delete it
 	// by hand. Validate now; if any referenced dir is gone, drop the file (and
@@ -193,7 +211,7 @@ func ensureMobileBuildSetup() error {
 		// module: a partial clone (process killed between MkdirAll and
 		// checkout) must be removed and re-cloned, or the regenerated
 		// go.work would point at a directory Go still cannot load.
-		mobileDir := filepath.Join(os.TempDir(), "golang-mobile")
+		mobileDir := mobileCloneDir()
 		if !mobileCloneUsable(mobileDir) {
 			if _, statErr := os.Stat(mobileDir); statErr == nil {
 				fmt.Println("Removing unusable or stale x/mobile clone...")
@@ -481,8 +499,9 @@ func goWorkIrgoGenerated(path string) bool {
 	// the loop below via isIrgoCheckout's strict exact-path parse instead,
 	// which covers the discovered checkout and any previous one alike.
 	known := map[string]bool{
-		filepath.Clean("."):                          true,
-		filepath.Join(os.TempDir(), "golang-mobile"): true,
+		filepath.Clean("."):    true,
+		mobileCloneDir():       true,
+		legacyMobileCloneDir(): true,
 	}
 
 	dir := filepath.Dir(path)

--- a/cmd/irgo/gowork_test.go
+++ b/cmd/irgo/gowork_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -591,4 +592,38 @@ func TestMobileCloneUsable(t *testing.T) {
 			t.Fatal("expected unverifiable revision to be unusable")
 		}
 	})
+}
+
+// TestMobileCloneSurvivesTempCleanup — the clone must not live anywhere the
+// operating system sweeps.
+//
+// It used to sit in $TMPDIR. macOS clears that periodically, and once it goes
+// the generated go.work names a directory that is not there. Every `go`
+// command in the project then fails, including `go tool irgo` and
+// `go run ./cmd/irgo` — so irgo cannot regenerate the file it wrote, and the
+// error never suggests the fix, which is deleting go.work by hand.
+func TestMobileCloneSurvivesTempCleanup(t *testing.T) {
+	dir := mobileCloneDir()
+
+	if tmp := os.TempDir(); strings.HasPrefix(dir, filepath.Clean(tmp)) {
+		t.Errorf("the x/mobile clone is in %s, which the OS may delete.\n"+
+			"When it does, go.work references a missing directory and no go "+
+			"command can run — including the one that would repair it.", tmp)
+	}
+	if !strings.Contains(dir, ".irgo") {
+		t.Errorf("clone at %s is outside irgo's own directory, so `tools remove` "+
+			"cannot account for it", dir)
+	}
+}
+
+// TestLegacyCloneIsStillRecognised — a workspace written by an older irgo
+// points at the old temp location. It has to keep being identified as irgo's,
+// or the file it wrote becomes something a user has to diagnose alone.
+func TestLegacyCloneIsStillRecognised(t *testing.T) {
+	if legacyMobileCloneDir() == mobileCloneDir() {
+		t.Fatal("legacy and current clone paths are the same; the legacy check is dead code")
+	}
+	if filepath.Base(legacyMobileCloneDir()) != "golang-mobile" {
+		t.Error("the legacy path no longer matches what older versions wrote")
+	}
 }


### PR DESCRIPTION
The gomobile x/mobile checkout lived somewhere the OS sweeps periodically, so a
build that worked yesterday fails today with the clone simply gone — and the
error is about a missing package rather than a missing checkout.

Verified on the merge result with current main.
